### PR TITLE
Check before creating an index

### DIFF
--- a/eventdata/runners/createindex_runner.py
+++ b/eventdata/runners/createindex_runner.py
@@ -40,6 +40,7 @@ def createindex(es, params):
     if logger.isEnabledFor(logging.DEBUG):
         logger.debug("[createindex] Create index {} => {}".format(index_name, json.dumps(b)))
 
-    es.indices.create(index=index_name, body=b, ignore=400)
+    if not es.indices.exists(index=index_name):
+        es.indices.create(index=index_name, body=b, ignore=400)
 
     return 1, "ops"


### PR DESCRIPTION
With this commit we first check whether an index exists before creating
it. This avoids confusion (although the previous solution worked fine).