### PR TITLE
Force merge index for frozen benchmarks

### DIFF
--- a/eventdata/challenges/frozen.json
+++ b/eventdata/challenges/frozen.json
@@ -20,7 +20,6 @@
         "index_template_body": {
           "template": "elasticlogs",
           "settings": {
-            "index.refresh_interval": "5s",
             "index.codec": "best_compression",
             "index.number_of_replicas": 0,
             "index.number_of_shards": 2
@@ -44,6 +43,13 @@
       },
       "iterations": 30000,
       "clients": 8
+    },
+    {
+      "operation": {
+        "operation-type": "force-merge",
+        "max-num-segments": 1,
+        "request-timeout": 7200
+      }
     }
   ]
 },


### PR DESCRIPTION
With this commit we force-merge the index that is used in the frozen
challenge to a single segment. We also set the refresh interval to its
default value to ensure an optimization in Elasticsearch can kick in
that disables refreshes if no searches are performed. This should
improve indexing speed a bit (we don't care about indexing speed in that
challenge as this only there to generate a decently sized corpus for the
query benchmark).