### PR TITLE
Add challenge to index fixed amount of daily logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,17 @@ The table below shows the track parameters that can be adjusted along with defau
 | `bulk_indexing_iterations` | Number of bulk requests to send as part of each run | `int` | `200000` |
 | `forcemerge` | Parameter indicating whether index statistics should be gathered following a forcemerge down to a single segment | `boolean` | `false` |
 
+### index-logs-fixed-daily-volume
+
+This challenge indexes a fixed amount of logs per day into daily indices. The table below shows the track parameters that can be adjusted along with default values:
+
+| Parameter               | Explanation                                                                                                                            | Type  | Default Value |
+| ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------- | ----- | ------------- |
+| `bulk_indexing_clients` | Number of bulk indexing clients/connections                                                                                            | `int` | `8`           |
+| `daily_logging_volume`  | The raw logging volume. Supported units are bytes (without any unit), `kb`, `MB` and `GB`). For the value, only integers are allowed.  | `str` | `100GB`       |
+| `number_of_days`        | The number of days for which data should be generated.                                                                                 | `int` | `24`          |
+| `shard_count`           | Number of primary shards                                                                                                               | `int` | `3`           |
+
 ## Custom parameter sources
 
 ### elasticlogs\_bulk\_source

--- a/eventdata/challenges/index-log-volume.json
+++ b/eventdata/challenges/index-log-volume.json
@@ -1,0 +1,49 @@
+{% set p_bulk_indexing_clients = (bulk_indexing_clients | default(8)) %}
+{% set p_number_of_days = (number_of_days | default(24)) %}
+{% set p_daily_logging_volume = (daily_logging_volume | default("100GB")) %}
+
+{
+  "name": "index-logs-fixed-daily-volume",
+  "description": "Indexes {{p_number_of_days}} days of logs with a fixed (raw) logging volume of {{p_daily_logging_volume}} per day",
+  "meta": {
+    "client_count": {{ p_bulk_indexing_clients }},
+    "benchmark_type": "logs-fixed-daily-volume"
+  },
+  "schedule": [
+    {
+      "name": "delete-index-elasticlogs-*",
+      "operation": {
+        "operation-type": "delete-index",
+        "index": "elasticlogs-*"
+      }
+    },
+    {
+      "operation": "delete-index-template"
+    },
+    {
+      "operation": {
+        "operation-type": "create-index-template",
+        "settings": {
+          "index.number_of_shards": {{ shard_count | default(3) }}
+        }
+      }
+    },
+    {
+      "name": "bulk-index-logs",
+      "operation": {
+        "operation-type": "bulk",
+        "param-source": "elasticlogs_bulk",
+        "index": "elasticlogs-<yyyy>-<mm>-<dd>",
+        "starting_point": "2018-05-01:00:00:00",
+        "bulk-size": 1000,
+        "daily_logging_volume": "{{p_daily_logging_volume}}",
+        "number_of_days": {{p_number_of_days}},
+        "record_raw_event_size": {{p_record_raw_event_size}}
+      },
+      "warmup-time-period": 0,
+      "#COMMENT": "We need to have the parameter source define this!",
+      "time-period": 72000,
+      "clients": {{ p_bulk_indexing_clients }}
+    }
+  ]
+}

--- a/eventdata/operations/indexing.json
+++ b/eventdata/operations/indexing.json
@@ -25,7 +25,6 @@ rolledover_indices_suffix_separator: used by the `delete_rolledover_index_patter
   "param-source": "elasticlogs_bulk",
   "index": "elasticlogs",
   "starting_point": "2017-01-01:02:00:00",
-  "end_point": "2017-01-01:12:00:00",
   "bulk-size": 1000,
   "record_raw_event_size": {{p_record_raw_event_size}}
 },

--- a/eventdata/parameter_sources/elasticlogs_bulk_source.py
+++ b/eventdata/parameter_sources/elasticlogs_bulk_source.py
@@ -47,25 +47,13 @@ class ElasticlogsBulkSource:
                                         If a relative starting point (based on now) is provided, this will be used for generation.
                                         In the case an exact timestamp is provided as starting point, the difference to now will
                                         be calculated when the generation starts and this will be used as an offset for all events.
-                                        If an interval is provided by also specifying an end_point, the range will be calculated for
-                                        each bulk request and each event will be assigned a random timestamp withion this range.
-                                        starting point. Defaults to 'now'.
-        "end_point"                -    String specifying the end point for event time generation. It supports absolute or
-                                        relative values as follows:
-                                            'now'                 - Always evaluated to the current timestamp at time of generation
-                                            'now-1h'              - Offset to the current timestamp. Consists of a number and
-                                                                    either m (minutes), h (hours) or d (days).
-                                            '2017-02-20 20:12:32' - Exact timestamp.
-                                            '2017-02-20'          - Date. Time will be assumed to be 00:00:00.
-                                        When specified, the event timestamp will be generated randomly with in the interval defined
-                                        by the starting_point and end_point parameters. If end_poiunt < starting_point, they will be
-                                        swapped.
-        "acceleration_factor"      -    This factor only applies when an exact timestamp or date has been provided as starting point
-                                        and no end_point has been defined. It allows the time progression in the timestamp calculation
-                                        to be altered. A value larger than 1 will accelerate generation and a value lower than 1 will
-                                        slow it down. If a task is set up to run indexing for one hour with a fixed starting point of
-                                        '2016-12-20 20:12:32' and an acceleration factor of 2.0, events will be generated in timestamp
-                                        sequence covering a 2-hour window, '2017-02-20 20:12:32' to '2017-02-20 22:12:32' (approximately).
+                                        Defaults to 'now'.
+        "acceleration_factor"  -    This factor allows the time progression in the timestamp calculation to be altered.
+                                    A value larger than 1 will accelerate generation and a value lower than 1 will slow
+                                    it down. If a task is set up to run indexing for one hour with a fixed starting
+                                    point of '2016-12-20 20:12:32' and an acceleration factor of 2.0, events will be
+                                    generated in timestamp sequence covering a 2-hour window, '2017-02-20 20:12:32'
+                                    to '2017-02-20 22:12:32' (approximately).
         "id_type"                  -    Type of document id to use for generated documents. Defaults to `auto`.
                                             auto         - Do not explicitly set id and let Elasticsearch assign automatically.
                                             seq          - Assign sequentialy incrementing integer ids to each document.

--- a/eventdata/parameter_sources/metricbeat_bulk_source.py
+++ b/eventdata/parameter_sources/metricbeat_bulk_source.py
@@ -45,25 +45,13 @@ class MetricbeatBulkSource:
                                     If a relative starting point (based on now) is provided, this will be used for generation.
                                     In the case an exact timestamp is provided as starting point, the difference to now will
                                     be calculated when the generation starts and this will be used as an offset for all events. 
-                                    If an interval is provided by also specifying an end_point, the range will be calculated for 
-                                    each bulk request and each event will be assigned a random timestamp withion this range.
-                                    starting point. Defaults to 'now'.
-        "end_point"            -    String specifying the end point for event time generation. It supports absolute or
-                                    relative values as follows:
-                                        'now'                 - Always evaluated to the current timestamp at time of generation
-                                        'now-1h'              - Offset to the current timestamp. Consists of a number and 
-                                                                either m (minutes), h (hours) or d (days).
-                                        '2017-02-20 20:12:32' - Exact timestamp.
-                                        '2017-02-20'          - Date. Time will be assumed to be 00:00:00.
-                                    When specified, the event timestamp will be generated randomly with in the interval defined 
-                                    by the starting_point and end_point parameters. If end_poiunt < starting_point, they will be 
-                                    swapped. 
-        "acceleration_factor"  -    This factor only applies when an exact timestamp or date has been provided as starting point 
-                                    and no end_point has been defined. It allows the time progression in the timestamp calculation 
-                                    to be altered. A value larger than 1 will accelerate generation and a value lower than 1 will 
-                                    slow it down. If a task is set up to run indexing for one hour with a fixed starting point of 
-                                    '2016-12-20 20:12:32' and an acceleration factor of 2.0, events will be generated in timestamp 
-                                    sequence covering a 2-hour window, '2017-02-20 20:12:32' to '2017-02-20 22:12:32' (approximately).
+                                    Defaults to 'now'.
+        "acceleration_factor"  -    This factor allows the time progression in the timestamp calculation to be altered.
+                                    A value larger than 1 will accelerate generation and a value lower than 1 will slow
+                                    it down. If a task is set up to run indexing for one hour with a fixed starting
+                                    point of '2016-12-20 20:12:32' and an acceleration factor of 2.0, events will be
+                                    generated in timestamp sequence covering a 2-hour window, '2017-02-20 20:12:32'
+                                    to '2017-02-20 22:12:32' (approximately).
         "id_type"              -    Type of document id to use for generated documents. Defaults to `auto`.
                                         auto         - Do not explicitly set id and let Elasticsearch assign automatically.
                                         uuid         - Assign a UUID4 id to each document.

--- a/eventdata/parameter_sources/randomevent.py
+++ b/eventdata/parameter_sources/randomevent.py
@@ -317,7 +317,7 @@ class RandomEvent:
         event["hostname"] = "web-{}-{}.elastic.co".format(event["geoip_continent_code"], random.randrange(1, 3))
 
         if self.record_raw_event_size or self.daily_logging_volume:
-            # determine the raw event size (as if this were contained in nginx log file. We do not bother to
+            # determine the raw event size (as if this were contained in nginx log file). We do not bother to
             # reformat the timestamp as this is not worth the overhead.
             raw_event = '%s - - [%s] "%s %s HTTP/%s" %s %s "%s" "%s"' % (event["clientip"], event["@timestamp"],
                                                                          event["verb"], event["request"],

--- a/eventdata/parameter_sources/randomevent.py
+++ b/eventdata/parameter_sources/randomevent.py
@@ -260,7 +260,6 @@ class RandomEvent:
         self._type = "doc"
         self._timestamp_generator = TimestampStructGenerator(
             params.get("starting_point", "now"),
-            params.get("end_point"),
             float(params.get("acceleration_factor", "1.0"))
         )
 

--- a/eventdata/parameter_sources/randomevent.py
+++ b/eventdata/parameter_sources/randomevent.py
@@ -266,7 +266,7 @@ class RandomEvent:
         self.record_raw_event_size = params.get("record_raw_event_size", False)
 
     def generate_event(self):
-        timestruct = self._timestamp_generator.generate_timestamp_struct()
+        timestruct = self._timestamp_generator.next_timestamp()
         index_name = self.__generate_index_pattern(timestruct)
 
         event = self._event

--- a/eventdata/parameter_sources/timeutils.py
+++ b/eventdata/parameter_sources/timeutils.py
@@ -33,8 +33,8 @@ class TimeParsingError(Exception):
 
 
 class TimestampStructGenerator:
-    def __init__(self, starting_point, acceleration_factor=1.0, utcnow=datetime.datetime.utcnow):
-        self._utcnow = utcnow
+    def __init__(self, starting_point, acceleration_factor=1.0, utcnow=None):
+        self._utcnow = utcnow if utcnow else datetime.datetime.utcnow
         # the (actual) time when this generator has started
         self._start = self._utcnow()
         # the logical point in time for which we'll generate timestamps

--- a/eventdata/parameter_sources/timeutils.py
+++ b/eventdata/parameter_sources/timeutils.py
@@ -18,7 +18,6 @@
 
 import datetime
 import re
-import random
 
 epoch = datetime.datetime.utcfromtimestamp(0)
 
@@ -34,42 +33,21 @@ class TimeParsingError(Exception):
 
 
 class TimestampStructGenerator:
-    def __init__(self, starting_point, end_point=None, acceleration_factor=1.0, utcnow=datetime.datetime.utcnow):
+    def __init__(self, starting_point, acceleration_factor=1.0, utcnow=datetime.datetime.utcnow):
         self._start_dt = None
         self._starting_point = self.__parse_point_def(starting_point)
-        if end_point is None:
-            self._end_point = None
-        else:
-            self._end_point = self.__parse_point_def(end_point)
         self._acceleration_factor = acceleration_factor
         self._utcnow = utcnow
         # reuse to reduce object churn
         self._ts = {}
 
     def generate_timestamp_struct(self):
-        if self._end_point is None:
-            if self._starting_point["type"] == "relative":
-                dt = self._utcnow() + self._starting_point["offset"]
-            else:
-                self.__set_start_dt_if_not_set()
-                td = (self._utcnow() - self._start_dt) * self._acceleration_factor
-                dt = self._starting_point["dt"] + td
+        if self._starting_point["type"] == "relative":
+            dt = self._utcnow() + self._starting_point["offset"]
         else:
-            if self._starting_point["type"] == "relative":
-                dt1 = self._utcnow() + self._starting_point["offset"]
-            else:
-                dt1 = self._starting_point["dt"]
-
-            if self._end_point["type"] == "relative":
-                dt2 = self._utcnow() + self._end_point["offset"]
-            else:
-                dt2 = self._end_point["dt"]
-
-            interval_length = (dt2 - dt1)
-            random_offset = interval_length * random.random()
-
-            dt = dt1 + random_offset
-
+            self.__set_start_dt_if_not_set()
+            td = (self._utcnow() - self._start_dt) * self._acceleration_factor
+            dt = self._starting_point["dt"] + td
         return self.__generate_timestamp_struct_from_datetime(dt)
 
     def __generate_timestamp_struct_from_datetime(self, dt):

--- a/eventdata/parameter_sources/timeutils.py
+++ b/eventdata/parameter_sources/timeutils.py
@@ -34,23 +34,20 @@ class TimeParsingError(Exception):
 
 class TimestampStructGenerator:
     def __init__(self, starting_point, acceleration_factor=1.0, utcnow=datetime.datetime.utcnow):
-        self._start_dt = None
+        self._utcnow = utcnow
+        # the (actual) time when this generator has started
+        self._start = self._utcnow()
+        # the logical point in time for which we'll generate timestamps
         self._starting_point = self.__parse_point_def(starting_point)
         self._acceleration_factor = acceleration_factor
-        self._utcnow = utcnow
         # reuse to reduce object churn
         self._ts = {}
 
-    def generate_timestamp_struct(self):
-        if self._starting_point["type"] == "relative":
-            dt = self._utcnow() + self._starting_point["offset"]
-        else:
-            self.__set_start_dt_if_not_set()
-            td = (self._utcnow() - self._start_dt) * self._acceleration_factor
-            dt = self._starting_point["dt"] + td
-        return self.__generate_timestamp_struct_from_datetime(dt)
+    def next_timestamp(self):
+        delta = (self._utcnow() - self._start) * self._acceleration_factor
+        return self.__to_struct(self._starting_point + delta)
 
-    def __generate_timestamp_struct_from_datetime(self, dt):
+    def __to_struct(self, dt):
         # string formatting is about 4 times faster than strftime.
         iso = "%04d-%02d-%02dT%02d:%02d:%02d.%03dZ" % (dt.year, dt.month, dt.day, dt.hour, dt.minute, dt.second, dt.microsecond)
         self._ts["iso"] = iso
@@ -61,46 +58,42 @@ class TimestampStructGenerator:
         self._ts["hh"] = iso[11:13]
         return self._ts
 
-    def __set_start_dt_if_not_set(self):
-        if self._start_dt is None:
-            self._start_dt = self._utcnow()
-
     def __parse_point_def(self, point):
         if point == "now":
-            return {"type": "relative", "offset": datetime.timedelta()}
+            # this is "now" at this point
+            return self._start
 
         match = re.match(r"^now([+-]\d+)([hmd])$", point)
         if match:
-            offset = int(match.group(1))
+            offset_amount = int(match.group(1))
 
             if match.group(2) == "m":
-                return {'type': "relative", "offset": datetime.timedelta(minutes=offset)}
+                offset = datetime.timedelta(minutes=offset_amount)
+            elif match.group(2) == "h":
+                offset = datetime.timedelta(hours=offset_amount)
+            elif match.group(2) == "d":
+                offset = datetime.timedelta(days=offset_amount)
+            else:
+                raise TimeParsingError("Invalid time format: {}".format(point))
 
-            if match.group(2) == "h":
-                return {'type': "relative", "offset": datetime.timedelta(hours=offset)}
-
-            if match.group(2) == "d":
-                return {'type': "relative", "offset": datetime.timedelta(days=offset)}
+            return self._start + offset
 
         else:
             match = re.match(r"^(\d{4})\D(\d{2})\D(\d{2})\D(\d{2})\D(\d{2})\D(\d{2})$", point)
             if match:
-                dt = datetime.datetime(year=int(match.group(1)),
-                                       month=int(match.group(2)),
-                                       day=int(match.group(3)),
-                                       hour=int(match.group(4)),
-                                       minute=int(match.group(5)),
-                                       second=int(match.group(6)),
-                                       tzinfo=datetime.timezone.utc)
-                return {"type": "absolute", "dt": dt}
-
+                return datetime.datetime(year=int(match.group(1)),
+                                         month=int(match.group(2)),
+                                         day=int(match.group(3)),
+                                         hour=int(match.group(4)),
+                                         minute=int(match.group(5)),
+                                         second=int(match.group(6)),
+                                         tzinfo=datetime.timezone.utc)
             else:
                 match = re.match(r"^(\d{4})\D(\d{2})\D(\d{2})$", point)
                 if match:
-                    dt = datetime.datetime(year=int(match.group(1)),
-                                           month=int(match.group(2)),
-                                           day=int(match.group(3)),
-                                           tzinfo=datetime.timezone.utc)
-                    return {"type": "absolute", "dt": dt}
+                    return datetime.datetime(year=int(match.group(1)),
+                                             month=int(match.group(2)),
+                                             day=int(match.group(3)),
+                                             tzinfo=datetime.timezone.utc)
 
         raise TimeParsingError("Invalid time format: {}".format(point))

--- a/eventdata/parameter_sources/timeutils.py
+++ b/eventdata/parameter_sources/timeutils.py
@@ -47,6 +47,12 @@ class TimestampStructGenerator:
         delta = (self._utcnow() - self._start) * self._acceleration_factor
         return self.__to_struct(self._starting_point + delta)
 
+    def skip(self, delta):
+        # advance the generated timestamp by delta
+        self._starting_point = self._starting_point + delta
+        # also reset the generator start as we want to ensure the same delta in #next_timestamp()
+        self._start = self._utcnow()
+
     def __to_struct(self, dt):
         # string formatting is about 4 times faster than strftime.
         iso = "%04d-%02d-%02dT%02d:%02d:%02d.%03dZ" % (dt.year, dt.month, dt.day, dt.hour, dt.minute, dt.second, dt.microsecond)

--- a/tests/parameter_sources/randomevent_test.py
+++ b/tests/parameter_sources/randomevent_test.py
@@ -1,0 +1,174 @@
+import json
+from datetime import datetime
+
+import pytest
+
+from eventdata.parameter_sources.randomevent import RandomEvent, convert_to_bytes
+
+
+# Adds all relevant fields for an event
+class StaticAgent:
+    def add_fields(self, event):
+        event["useragent_name"] = "Chrome"
+        event["useragent_os"] = "MacOS"
+        event["useragent_os_name"] = "MacOS"
+        event["useragent_device"] = "Intel Mac"
+        event["useragent_os_major"] = "10"
+        event["useragent_major"] = "60"
+        event[
+            "agent"] = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.66 Safari/537.36"
+
+
+class StaticClientIp:
+    def add_fields(self, event):
+        event["clientip"] = "127.0.0.1"
+        event["geoip_location_lat"] = "0"
+        event["geoip_location_lon"] = "0"
+        event["geoip_city_name"] = "Munich"
+        event["geoip_country_name"] = "Germany"
+        event["geoip_country_iso_code"] = "DE"
+        event["geoip_continent_name"] = "Europe"
+        event["geoip_continent_code"] = "1"
+
+
+class StaticReferrer:
+    def add_fields(self, event):
+        event["referrer"] = "https://www.google.com"
+
+
+class StaticRequest:
+    def add_fields(self, event):
+        event["request"] = "current/doc-values.html"
+        event["bytes"] = "3204"
+        event["verb"] = "GET"
+        event["response"] = "200"
+        event["httpversion"] = "1.1"
+
+
+def test_random_event_no_event_size_by_default():
+    e = RandomEvent(params={
+        "index": "logs",
+        "starting_point": "2019-01-05 15:00:00",
+    },
+        agent=StaticAgent,
+        client_ip=StaticClientIp,
+        referrer=StaticReferrer,
+        request=StaticRequest)
+
+    raw_doc, index, doc_type = e.generate_event()
+
+    doc = json.loads(raw_doc)
+    assert "_raw_event_size" not in doc
+    assert index == "logs"
+    assert doc_type == "doc"
+
+
+def test_random_event_with_event_size():
+    e = RandomEvent(params={
+        "index": "logs",
+        "starting_point": "2019-01-05 15:00:00",
+        "record_raw_event_size": True,
+        # we need a constant point in time to ensure a stable event size
+        "__utc_now": lambda: datetime(year=2019, month=6, day=17)
+    },
+        agent=StaticAgent,
+        client_ip=StaticClientIp,
+        referrer=StaticReferrer,
+        request=StaticRequest)
+
+    raw_doc, index, doc_type = e.generate_event()
+
+    doc = json.loads(raw_doc)
+    assert doc["_raw_event_size"] == 236
+    assert index == "logs"
+    assert doc_type == "doc"
+
+
+def test_random_events_with_daily_logging_volume():
+    e = RandomEvent(params={
+        "index": "logs-<yyyy><mm><dd>",
+        "starting_point": "2019-01-05 15:00:00",
+        # 1kB of data per client before we will rollover to the next day
+        "daily_logging_volume": "8kB",
+        "client_count": 8,
+        # we need a constant point in time to ensure a stable event size
+        "__utc_now": lambda: datetime(year=2019, month=6, day=17)
+    },
+        agent=StaticAgent,
+        client_ip=StaticClientIp,
+        referrer=StaticReferrer,
+        request=StaticRequest)
+
+    # 5 events fit into one kilobyte
+    for i in range(5):
+        doc, index, _ = e.generate_event()
+        assert index == "logs-20190105"
+    for i in range(5):
+        doc, index, _ = e.generate_event()
+        assert index == "logs-20190106"
+    for i in range(5):
+        doc, index, _ = e.generate_event()
+        assert index == "logs-20190107"
+
+
+def test_random_events_with_daily_logging_volume_and_maximum_days():
+    e = RandomEvent(params={
+        "index": "logs-<yyyy><mm><dd>",
+        "starting_point": "2019-01-05 15:00:00",
+        # 1kB of data per client before we will rollover to the next day
+        "daily_logging_volume": "8192",
+        "number_of_days": 2,
+        "client_count": 8,
+        # we need a constant point in time to ensure a stable event size
+        "__utc_now": lambda: datetime(year=2019, month=6, day=17)
+    },
+        agent=StaticAgent,
+        client_ip=StaticClientIp,
+        referrer=StaticReferrer,
+        request=StaticRequest)
+
+    # 5 events fit into one kilobyte
+    for i in range(5):
+        doc, index, _ = e.generate_event()
+        assert index == "logs-20190105"
+    for i in range(5):
+        doc, index, _ = e.generate_event()
+        assert index == "logs-20190106"
+    # no more events allowed on the next day
+    with pytest.raises(StopIteration):
+        doc, index, _ = e.generate_event()
+        print(index)
+
+
+
+def test_convert_bytes_to_bytes():
+    assert convert_to_bytes("3") == 3
+    assert convert_to_bytes("3786234876") == 3786234876
+
+
+def test_convert_kb_to_bytes():
+    assert convert_to_bytes("3 kB") == 3 * 1024
+    assert convert_to_bytes("3972 kB") == 3972 * 1024
+
+
+def test_convert_mb_to_bytes():
+    assert convert_to_bytes("100 MB") == 100 * 1024 * 1024
+    assert convert_to_bytes("10MB") == 10 * 1024 * 1024
+
+
+def test_convert_gb_to_bytes():
+    assert convert_to_bytes("3 GB") == 3 * 1024 * 1024 * 1024
+
+
+def test_convert_invalid_to_bytes():
+    with pytest.raises(ValueError) as ex:
+        convert_to_bytes("3.4")
+
+    assert "Invalid byte size value [3.4]" == str(ex.value)
+
+    with pytest.raises(ValueError) as ex:
+        convert_to_bytes("3gb")
+
+    assert "Invalid byte size value [3gb]" == str(ex.value)
+
+

--- a/tests/parameter_sources/timeutils_test.py
+++ b/tests/parameter_sources/timeutils_test.py
@@ -17,7 +17,6 @@
 
 import datetime
 import pytest
-import unittest.mock as mock
 
 from eventdata.parameter_sources.timeutils import TimestampStructGenerator, TimeParsingError
 
@@ -99,24 +98,6 @@ def test_generate_open_interval_from_fixed_starting_point():
         "mm": "05",
         "dd": "01",
         "hh": "01"
-    }
-
-
-@mock.patch("random.random")
-def test_generate_closed_interval_from_now(mocked_random):
-    # 0.2 * interval (one day) = 4 hours and 48 minutes
-    mocked_random.return_value = 0.2
-    clock = ReproducibleClock(start=datetime.datetime(year=2019, month=1, day=5, hour=15))
-
-    g = TimestampStructGenerator(starting_point="now", end_point="now+1d", utcnow=clock)
-
-    assert g.generate_timestamp_struct() == {
-        "iso": "2019-01-05T19:48:00.000Z",
-        "yyyy": "2019",
-        "yy": "19",
-        "mm": "01",
-        "dd": "05",
-        "hh": "19"
     }
 
 

--- a/tests/parameter_sources/timeutils_test.py
+++ b/tests/parameter_sources/timeutils_test.py
@@ -102,6 +102,53 @@ def test_generate_interval_from_fixed_starting_point():
     }
 
 
+def test_generate_interval_and_skip():
+    clock = ReproducibleClock(start=datetime.datetime(year=2019, month=1, day=5, hour=15),
+                              delta=datetime.timedelta(seconds=1))
+
+    g = TimestampStructGenerator(starting_point="2018-05-01:00:59:56",
+                                 acceleration_factor=3.0,
+                                 utcnow=clock)
+
+    assert g.next_timestamp() == {
+        "iso": "2018-05-01T00:59:59.000Z",
+        "yyyy": "2018",
+        "yy": "18",
+        "mm": "05",
+        "dd": "01",
+        "hh": "00"
+    }
+
+    assert g.next_timestamp() == {
+        "iso": "2018-05-01T01:00:02.000Z",
+        "yyyy": "2018",
+        "yy": "18",
+        "mm": "05",
+        "dd": "01",
+        "hh": "01"
+    }
+
+    g.skip(datetime.timedelta(days=1))
+
+    assert g.next_timestamp() == {
+        "iso": "2018-05-02T00:59:59.000Z",
+        "yyyy": "2018",
+        "yy": "18",
+        "mm": "05",
+        "dd": "02",
+        "hh": "00"
+    }
+
+    assert g.next_timestamp() == {
+        "iso": "2018-05-02T01:00:02.000Z",
+        "yyyy": "2018",
+        "yy": "18",
+        "mm": "05",
+        "dd": "02",
+        "hh": "01"
+    }
+
+
 def test_generate_invalid_time_interval():
     # "w" is unsupported
     with pytest.raises(TimeParsingError) as ex:

--- a/tests/parameter_sources/timeutils_test.py
+++ b/tests/parameter_sources/timeutils_test.py
@@ -32,22 +32,14 @@ class ReproducibleClock:
         return now
 
 
-def test_generate_open_interval_from_now():
+def test_generate_interval_from_now():
     clock = ReproducibleClock(start=datetime.datetime(year=2019, month=1, day=5, hour=15),
                               delta=datetime.timedelta(seconds=5))
 
     g = TimestampStructGenerator(starting_point="now", utcnow=clock)
 
-    assert g.generate_timestamp_struct() == {
-        "iso": "2019-01-05T15:00:00.000Z",
-        "yyyy": "2019",
-        "yy": "19",
-        "mm": "01",
-        "dd": "05",
-        "hh": "15"
-    }
-
-    assert g.generate_timestamp_struct() == {
+    # first generated timestamp will be one (clock) invocation after the original start
+    assert g.next_timestamp() == {
         "iso": "2019-01-05T15:00:05.000Z",
         "yyyy": "2019",
         "yy": "19",
@@ -56,7 +48,7 @@ def test_generate_open_interval_from_now():
         "hh": "15"
     }
 
-    assert g.generate_timestamp_struct() == {
+    assert g.next_timestamp() == {
         "iso": "2019-01-05T15:00:10.000Z",
         "yyyy": "2019",
         "yy": "19",
@@ -65,8 +57,17 @@ def test_generate_open_interval_from_now():
         "hh": "15"
     }
 
+    assert g.next_timestamp() == {
+        "iso": "2019-01-05T15:00:15.000Z",
+        "yyyy": "2019",
+        "yy": "19",
+        "mm": "01",
+        "dd": "05",
+        "hh": "15"
+    }
 
-def test_generate_open_interval_from_fixed_starting_point():
+
+def test_generate_interval_from_fixed_starting_point():
     clock = ReproducibleClock(start=datetime.datetime(year=2019, month=1, day=5, hour=15),
                               delta=datetime.timedelta(seconds=1))
 
@@ -74,7 +75,7 @@ def test_generate_open_interval_from_fixed_starting_point():
                                  acceleration_factor=3.0,
                                  utcnow=clock)
 
-    assert g.generate_timestamp_struct() == {
+    assert g.next_timestamp() == {
         "iso": "2018-05-01T00:59:59.000Z",
         "yyyy": "2018",
         "yy": "18",
@@ -83,7 +84,7 @@ def test_generate_open_interval_from_fixed_starting_point():
         "hh": "00"
     }
 
-    assert g.generate_timestamp_struct() == {
+    assert g.next_timestamp() == {
         "iso": "2018-05-01T01:00:02.000Z",
         "yyyy": "2018",
         "yy": "18",
@@ -91,7 +92,7 @@ def test_generate_open_interval_from_fixed_starting_point():
         "dd": "01",
         "hh": "01"
     }
-    assert g.generate_timestamp_struct() == {
+    assert g.next_timestamp() == {
         "iso": "2018-05-01T01:00:05.000Z",
         "yyyy": "2018",
         "yy": "18",


### PR DESCRIPTION
With this commit we add a new challenge `index-logs-fixed-daily-volume` which
allows to ingest a fixed (but parameterizable) amount of raw logs per day. Also,
the number of days can be specified.

We also extend the existing generator with new parameters to allow this and
significantly increase testing coverage in that area after simplifying some
complex but rarely needed code in the timestamp generator.