### PR TITLE
Adjust to new parameter source API

### DIFF
--- a/eventdata/parameter_sources/elasticlogs_bulk_source.py
+++ b/eventdata/parameter_sources/elasticlogs_bulk_source.py
@@ -77,6 +77,7 @@ class ElasticlogsBulkSource:
         "id_delay_secs"            -    If an event is delayed, this number of seconds will be deducted from the current timestamp.
     """
     def __init__(self, track, params, **kwargs):
+        self.infinite = False
         self.orig_args = [track, params, kwargs]
         self._indices = track.indices
         self._params = params
@@ -136,15 +137,16 @@ class ElasticlogsBulkSource:
         new_params["client_count"] = total_partitions
         return ElasticlogsBulkSource(self.orig_args[0], new_params, **self.orig_args[2])
 
+    # Deprecated - only there for BWC reasons with Rally < 1.4.0
     def size(self):
-        # progress is determined either by:
-        #
-        # * the `time-period` or `iteration` property specified on the corresponding task
-        # * `#params()` raising `StopIteration` when `RandomEvent` is exhausted
         return None
 
     @property
     def percent_completed(self):
+        # progress is determined either by:
+        #
+        # * the `time-period` or `iteration` property specified on the corresponding task
+        # * `#params()` raising `StopIteration` when `RandomEvent` is exhausted
         return self._randomevent.percent_completed
 
     def params(self):

--- a/eventdata/parameter_sources/elasticlogs_kibana_source.py
+++ b/eventdata/parameter_sources/elasticlogs_kibana_source.py
@@ -91,6 +91,7 @@ class ElasticlogsKibanaSource:
         self._debug = params.get("debug", False)
         self._pre_filter_shard_size = params.get("pre_filter_shard_size", 1)
         self._window_length = params.get("window_length", "1d")
+        self.infinite = True
         
         random.seed()
 
@@ -155,8 +156,9 @@ class ElasticlogsKibanaSource:
         random.seed(seed)
         return self
 
+    # Deprecated - only there for BWC reasons with Rally < 1.4.0
     def size(self):
-        return 1
+        return None
 
     def params(self):
         # Determine window_end boundaries


### PR DESCRIPTION
With this commit we change the existing parameter sources to conform to
a new API for parameter sources in Rally. We also keep the old methods
for backwards compatibility with older releases of Rally.

Relates elastic/rally#763