### PR TITLE
Use correct property for index in update challenge

### DIFF
--- a/eventdata/challenges/bulk-update.json
+++ b/eventdata/challenges/bulk-update.json
@@ -18,7 +18,7 @@
     {
       "operation": {
         "operation-type": "create-index",
-        "index_name": "elasticlogs",
+        "index": "elasticlogs",
         "settings": {
             {% if index_refresh_interval is defined %}
             "index.refresh_interval": {{ index_refresh_interval | int }},


### PR DESCRIPTION
With this commit we use the correct property `index` in the
`bulk-update` challenge instead of the outdated property name
`index_name`. This is a leftover from #36.

`index_name` was getting ignored up until #36 because there was an 
[indices section](https://github.com/elastic/rally-eventdata-track/blob/e39208732d76a3918dbb4926d7e3f6d77eee7941/eventdata/track.json#L8-L13) having a default index (coincidentally with the same name as specified in the challenge).
With #36 `indices` got removed and became a [template](https://github.com/elastic/rally-eventdata-track/pull/36/files#diff-690d3782ebf9f9cca6b678ed111ded38R9)
causing this challenge to fail warning about the unknown property `index_name`.