### PR TITLE
Cleanup Kibana Parameter Source

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ The generator allows data to be generated in real-time or against a set date/tin
 
 ### elasticlogs\_kibana\_source
 
-This parameter source supports simulating two different types of dashboards.
+This parameter source supports simulating three different types of dashboards.
 
 **traffic** - This dashboard contains 7 visualisations and presents different types of traffic statistics. In structure it is similar to the `Nginx Overview` dashboard that comes with the Filebeat Nginx Module. It does aggregate across all records in the index and is therefore a quite 'heavy' dashboard.
 

--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ The generator allows data to be generated in real-time or against a set date/tin
 
 ### elasticlogs\_kibana\_source
 
-This parameter source supports simulating three different types of dashboards.
+This parameter source supports simulating three different types of dashboards. One of the following needs to be selected by specifying the mandatory parameter `dashboard`:
 
 **traffic** - This dashboard contains 7 visualisations and presents different types of traffic statistics. In structure it is similar to the `Nginx Overview` dashboard that comes with the Filebeat Nginx Module. It does aggregate across all records in the index and is therefore a quite 'heavy' dashboard.
 

--- a/eventdata/parameter_sources/elasticlogs_kibana_source.py
+++ b/eventdata/parameter_sources/elasticlogs_kibana_source.py
@@ -279,21 +279,6 @@ class ElasticlogsKibanaSource:
 
         return window_end_spec
 
-    def __unit_string_to_milliseconds(self, string):
-        m = re.match(r"^(\d+\.*\d*)([dhm])$", string)
-        if m:
-            val = float(m.group(1))
-            unit = m.group(2)
-
-            if unit == "m":
-                return False, int(60*val*1000)
-            elif unit == "h":
-                return False, int(3600*val*1000)
-            else:
-                return False, int(86400*val*1000)
-        else:
-            return True, None
-
     def __determine_interval(self, window_size_seconds, target_bars, max_bars):
         available_intervals = [
             {"unit": "1s",      "length_sec": 1},
@@ -340,11 +325,6 @@ class ElasticlogsKibanaSource:
 
     def __get_preference(self):
         return int(round(time.time() * 1000))
-
-    def __print_ts(self, ts):
-        ts_s = int(ts / 1000)
-        dt = datetime.datetime.utcfromtimestamp(ts_s)
-        return dt.isoformat()
 
     def __content_issues_dashboard(self, index_pattern, query_string, interval, ts_min_ms, ts_max_ms, ignore_throttled):
         preference = self.__get_preference()

--- a/tests/parameter_sources/__init__.py
+++ b/tests/parameter_sources/__init__.py
@@ -14,3 +14,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+
+
+class StaticTrack:
+    def __init__(self):
+        self.indices = []

--- a/tests/parameter_sources/elasticlogs_bulk_source_test.py
+++ b/tests/parameter_sources/elasticlogs_bulk_source_test.py
@@ -1,4 +1,5 @@
 from eventdata.parameter_sources.elasticlogs_bulk_source import ElasticlogsBulkSource
+from parameter_sources import StaticTrack
 
 
 class StaticEventGenerator:
@@ -13,11 +14,6 @@ class StaticEventGenerator:
             raise StopIteration()
         self.at_most -= 1
         return self.doc, self.index, self.type
-
-
-class StaticTrack:
-    def __init__(self):
-        self.indices = []
 
 
 def test_generates_a_complete_bulk():

--- a/tests/parameter_sources/elasticlogs_bulk_source_test.py
+++ b/tests/parameter_sources/elasticlogs_bulk_source_test.py
@@ -1,5 +1,5 @@
 from eventdata.parameter_sources.elasticlogs_bulk_source import ElasticlogsBulkSource
-from parameter_sources import StaticTrack
+from tests.parameter_sources import StaticTrack
 
 
 class StaticEventGenerator:

--- a/tests/parameter_sources/elasticlogs_kibana_source_test.py
+++ b/tests/parameter_sources/elasticlogs_kibana_source_test.py
@@ -1,0 +1,123 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from datetime import datetime
+from unittest import mock
+
+import pytest
+
+from eventdata.parameter_sources.elasticlogs_kibana_source import ElasticlogsKibanaSource, ConfigurationError
+from parameter_sources import StaticTrack
+
+
+@mock.patch("time.time")
+def test_create_discover(time):
+    time.return_value = 5000
+
+    param_source = ElasticlogsKibanaSource(track=StaticTrack(), params={
+        "dashboard": "discover"
+    }, utcnow=lambda: datetime(year=2019, month=11, day=11))
+    response = param_source.params()
+
+    assert response == {
+        "body": [
+            {
+                "index": "elasticlogs-*",
+                "ignore_unavailable": True,
+                "preference": 5000000,
+                "ignore_throttled": True
+            },
+            {
+                "version": True,
+                "size": 500,
+                "sort": [
+                    {"@timestamp": {"order": "desc", "unmapped_type": "boolean"}}
+                ],
+                "_source": {"excludes": []},
+                "aggs": {
+                    "2": {
+                        "date_histogram": {
+                            "field": "@timestamp",
+                            "interval": "30m",
+                            "time_zone": "Europe/London",
+                            "min_doc_count": 1}
+                    }
+                },
+                "stored_fields": ["*"],
+                "script_fields": {},
+                "docvalue_fields": [
+                    {"field": "@timestamp", "format": "date_time"}
+                ],
+                "query": {
+                    "bool": {
+                        "must": [
+                            {
+                                "query_string": {
+                                    "query": "*",
+                                    "analyze_wildcard": True,
+                                    "default_field": "*"
+                                }
+                            },
+                            {
+                                "range": {
+                                    "@timestamp": {
+                                        "gte": 1573344000000,
+                                        "lte": 1573430400000,
+                                        "format": "epoch_millis"
+                                    }
+                                }
+                            }
+                        ],
+                        "filter": [],
+                        "should": [],
+                        "must_not": []
+                    }
+                },
+                "highlight": {
+                    "pre_tags": ["@kibana-highlighted-field@"],
+                    "post_tags": ["@/kibana-highlighted-field@"],
+                    "fields": {"*": {}},
+                    "fragment_size": 2147483647
+                }
+            }
+        ],
+        "meta_data": {
+            "interval": "30m",
+            "index_pattern": "elasticlogs-*",
+            "query_string": "*",
+            "dashboard": "discover",
+            "window_length": "1d",
+            "ignore_throttled": True,
+            "pre_filter_shard_size": 1,
+            "debug": False
+        }
+    }
+
+
+def test_dashboard_is_mandatory():
+    with pytest.raises(KeyError) as ex:
+        ElasticlogsKibanaSource(track=StaticTrack(), params={})
+
+    assert "'dashboard'" == str(ex.value)
+
+
+def test_invalid_dashboard_raises_error():
+    with pytest.raises(ConfigurationError) as ex:
+        ElasticlogsKibanaSource(track=StaticTrack(), params={"dashboard": "unknown"})
+
+    assert "Unknown dashboard [unknown]. Must be one of ['traffic', 'content_issues', 'discover']." == str(ex.value)
+

--- a/tests/parameter_sources/elasticlogs_kibana_source_test.py
+++ b/tests/parameter_sources/elasticlogs_kibana_source_test.py
@@ -21,7 +21,7 @@ from unittest import mock
 import pytest
 
 from eventdata.parameter_sources.elasticlogs_kibana_source import ElasticlogsKibanaSource, ConfigurationError
-from parameter_sources import StaticTrack
+from tests.parameter_sources import StaticTrack
 
 
 @mock.patch("time.time")
@@ -59,9 +59,7 @@ def test_create_discover(time):
                 },
                 "stored_fields": ["*"],
                 "script_fields": {},
-                "docvalue_fields": [
-                    {"field": "@timestamp", "format": "date_time"}
-                ],
+                "docvalue_fields": ["@timestamp"],
                 "query": {
                     "bool": {
                         "must": [


### PR DESCRIPTION
With this commit we remove some dead code from the Kibana parameter source. We
also turn `dashboard` into a mandatory parameter and add tests.