### PR TITLE
Use fixed_interval instead of interval for Kibana

### DIFF
--- a/eventdata/parameter_sources/elasticlogs_kibana_source.py
+++ b/eventdata/parameter_sources/elasticlogs_kibana_source.py
@@ -307,8 +307,8 @@ class ElasticlogsKibanaSource:
             {"unit": "7d",   "length_sec": 604800},
             # month - use 30d for fixed_interval
             {"unit": "30d",  "length_sec": 2592000},
-            # quarter - use 91d for fixed_interval
-            {"unit": "91d",  "length_sec": 7776000},
+            # quarter - use 90d for fixed_interval
+            {"unit": "90d",  "length_sec": 7776000},
             # year - use 365d for fixed_interval
             {"unit": "365d", "length_sec": 31536000}
         ]

--- a/tests/parameter_sources/elasticlogs_kibana_source_test.py
+++ b/tests/parameter_sources/elasticlogs_kibana_source_test.py
@@ -96,4 +96,6 @@ def test_determine_interval():
         (100000000,    "30d"),
     ]
     for window_size, expected_interval in test_params:
-        assert ElasticlogsKibanaSource.determine_interval(window_size_seconds=window_size, target_bars=50, max_bars=100) == expected_interval
+        assert ElasticlogsKibanaSource.determine_interval(window_size_seconds=window_size,
+                                                          target_bars=50,
+                                                          max_bars=100) == expected_interval

--- a/tests/parameter_sources/resources/expected-content_issues.json
+++ b/tests/parameter_sources/resources/expected-content_issues.json
@@ -1,0 +1,414 @@
+{
+  "body": [
+    {
+      "ignore_throttled": true,
+      "ignore_unavailable": true,
+      "index": "elasticlogs-*",
+      "preference": 5000000
+    },
+    {
+      "_source": {
+        "excludes": []
+      },
+      "aggs": {
+        "2": {
+          "cardinality": {
+            "field": "nginx.access.remote_ip"
+          }
+        }
+      },
+      "docvalue_fields": [
+        "@timestamp"
+      ],
+      "highlight": {
+        "fields": {
+          "*": {}
+        },
+        "fragment_size": 2147483647,
+        "post_tags": [
+          "@/kibana-highlighted-field@"
+        ],
+        "pre_tags": [
+          "@kibana-highlighted-field@"
+        ]
+      },
+      "query": {
+        "bool": {
+          "filter": [],
+          "must": [
+            {
+              "match_all": {}
+            },
+            {
+              "match_all": {}
+            },
+            {
+              "query_string": {
+                "analyze_wildcard": true,
+                "default_field": "*",
+                "query": "*"
+              }
+            },
+            {
+              "match_phrase": {
+                "nginx.access.response_code": {
+                  "query": 404
+                }
+              }
+            },
+            {
+              "range": {
+                "@timestamp": {
+                  "format": "epoch_millis",
+                  "gte": 1573344000000,
+                  "lte": 1573430400000
+                }
+              }
+            }
+          ],
+          "must_not": [],
+          "should": []
+        }
+      },
+      "script_fields": {},
+      "size": 0,
+      "stored_fields": [
+        "*"
+      ],
+      "version": true
+    },
+    {
+      "ignore_throttled": true,
+      "ignore_unavailable": true,
+      "index": "elasticlogs-*",
+      "preference": 5000000
+    },
+    {
+      "_source": {
+        "excludes": []
+      },
+      "aggs": {
+        "2": {
+          "terms": {
+            "field": "nginx.access.remote_ip",
+            "order": {
+              "_count": "desc"
+            },
+            "size": 20
+          }
+        }
+      },
+      "docvalue_fields": [
+        "@timestamp"
+      ],
+      "highlight": {
+        "fields": {
+          "*": {}
+        },
+        "fragment_size": 2147483647,
+        "post_tags": [
+          "@/kibana-highlighted-field@"
+        ],
+        "pre_tags": [
+          "@kibana-highlighted-field@"
+        ]
+      },
+      "query": {
+        "bool": {
+          "filter": [],
+          "must": [
+            {
+              "match_all": {}
+            },
+            {
+              "match_all": {}
+            },
+            {
+              "query_string": {
+                "analyze_wildcard": true,
+                "default_field": "*",
+                "query": "*"
+              }
+            },
+            {
+              "match_phrase": {
+                "nginx.access.response_code": {
+                  "query": 404
+                }
+              }
+            },
+            {
+              "range": {
+                "@timestamp": {
+                  "format": "epoch_millis",
+                  "gte": 1573344000000,
+                  "lte": 1573430400000
+                }
+              }
+            }
+          ],
+          "must_not": [],
+          "should": []
+        }
+      },
+      "script_fields": {},
+      "size": 0,
+      "stored_fields": [
+        "*"
+      ],
+      "version": true
+    },
+    {
+      "ignore_throttled": true,
+      "ignore_unavailable": true,
+      "index": "elasticlogs-*",
+      "preference": 5000000
+    },
+    {
+      "_source": {
+        "excludes": []
+      },
+      "aggs": {
+        "2": {
+          "terms": {
+            "field": "nginx.access.url",
+            "order": {
+              "_count": "desc"
+            },
+            "size": 20
+          }
+        }
+      },
+      "docvalue_fields": [
+        "@timestamp"
+      ],
+      "highlight": {
+        "fields": {
+          "*": {}
+        },
+        "fragment_size": 2147483647,
+        "post_tags": [
+          "@/kibana-highlighted-field@"
+        ],
+        "pre_tags": [
+          "@kibana-highlighted-field@"
+        ]
+      },
+      "query": {
+        "bool": {
+          "filter": [],
+          "must": [
+            {
+              "match_all": {}
+            },
+            {
+              "match_all": {}
+            },
+            {
+              "query_string": {
+                "analyze_wildcard": true,
+                "default_field": "*",
+                "query": "*"
+              }
+            },
+            {
+              "match_phrase": {
+                "nginx.access.response_code": {
+                  "query": 404
+                }
+              }
+            },
+            {
+              "range": {
+                "@timestamp": {
+                  "format": "epoch_millis",
+                  "gte": 1573344000000,
+                  "lte": 1573430400000
+                }
+              }
+            }
+          ],
+          "must_not": [],
+          "should": []
+        }
+      },
+      "script_fields": {},
+      "size": 0,
+      "stored_fields": [
+        "*"
+      ],
+      "version": true
+    },
+    {
+      "ignore_throttled": true,
+      "ignore_unavailable": true,
+      "index": "elasticlogs-*",
+      "preference": 5000000
+    },
+    {
+      "_source": {
+        "excludes": []
+      },
+      "aggs": {
+        "2": {
+          "terms": {
+            "field": "nginx.access.referrer",
+            "order": {
+              "_count": "desc"
+            },
+            "size": 20
+          }
+        }
+      },
+      "docvalue_fields": [
+        "@timestamp"
+      ],
+      "highlight": {
+        "fields": {
+          "*": {}
+        },
+        "fragment_size": 2147483647,
+        "post_tags": [
+          "@/kibana-highlighted-field@"
+        ],
+        "pre_tags": [
+          "@kibana-highlighted-field@"
+        ]
+      },
+      "query": {
+        "bool": {
+          "filter": [],
+          "must": [
+            {
+              "match_all": {}
+            },
+            {
+              "match_all": {}
+            },
+            {
+              "query_string": {
+                "analyze_wildcard": true,
+                "default_field": "*",
+                "query": "*"
+              }
+            },
+            {
+              "match_phrase": {
+                "nginx.access.response_code": {
+                  "query": 404
+                }
+              }
+            },
+            {
+              "range": {
+                "@timestamp": {
+                  "format": "epoch_millis",
+                  "gte": 1573344000000,
+                  "lte": 1573430400000
+                }
+              }
+            }
+          ],
+          "must_not": [],
+          "should": []
+        }
+      },
+      "script_fields": {},
+      "size": 0,
+      "stored_fields": [
+        "*"
+      ],
+      "version": true
+    },
+    {
+      "ignore_throttled": true,
+      "ignore_unavailable": true,
+      "index": "elasticlogs-*",
+      "preference": 5000000
+    },
+    {
+      "_source": {
+        "excludes": []
+      },
+      "aggs": {
+        "2": {
+          "date_histogram": {
+            "field": "@timestamp",
+            "fixed_interval": "30m",
+            "min_doc_count": 1,
+            "time_zone": "Europe/London"
+          }
+        }
+      },
+      "docvalue_fields": [
+        "@timestamp"
+      ],
+      "highlight": {
+        "fields": {
+          "*": {}
+        },
+        "fragment_size": 2147483647,
+        "post_tags": [
+          "@/kibana-highlighted-field@"
+        ],
+        "pre_tags": [
+          "@kibana-highlighted-field@"
+        ]
+      },
+      "query": {
+        "bool": {
+          "filter": [],
+          "must": [
+            {
+              "match_all": {}
+            },
+            {
+              "match_all": {}
+            },
+            {
+              "query_string": {
+                "analyze_wildcard": true,
+                "default_field": "*",
+                "query": "*"
+              }
+            },
+            {
+              "match_phrase": {
+                "nginx.access.response_code": {
+                  "query": 404
+                }
+              }
+            },
+            {
+              "range": {
+                "@timestamp": {
+                  "format": "epoch_millis",
+                  "gte": 1573344000000,
+                  "lte": 1573430400000
+                }
+              }
+            }
+          ],
+          "must_not": [],
+          "should": []
+        }
+      },
+      "script_fields": {},
+      "size": 0,
+      "stored_fields": [
+        "*"
+      ],
+      "version": true
+    }
+  ],
+  "meta_data": {
+    "dashboard": "content_issues",
+    "debug": false,
+    "ignore_throttled": true,
+    "index_pattern": "elasticlogs-*",
+    "interval": "30m",
+    "pre_filter_shard_size": 1,
+    "query_string": "*",
+    "window_length": "1d"
+  }
+}

--- a/tests/parameter_sources/resources/expected-discover.json
+++ b/tests/parameter_sources/resources/expected-discover.json
@@ -1,0 +1,71 @@
+{
+  "body": [
+    {
+      "index": "elasticlogs-*",
+      "ignore_unavailable": true,
+      "preference": 5000000,
+      "ignore_throttled": true
+    },
+    {
+      "version": true,
+      "size": 500,
+      "sort": [
+        {"@timestamp": {"order": "desc", "unmapped_type": "boolean"}}
+      ],
+      "_source": {"excludes": []},
+      "aggs": {
+        "2": {
+          "date_histogram": {
+            "field": "@timestamp",
+            "fixed_interval": "30m",
+            "time_zone": "Europe/London",
+            "min_doc_count": 1}
+        }
+      },
+      "stored_fields": ["*"],
+      "script_fields": {},
+      "docvalue_fields": ["@timestamp"],
+      "query": {
+        "bool": {
+          "must": [
+            {
+              "query_string": {
+                "query": "*",
+                "analyze_wildcard": true,
+                "default_field": "*"
+              }
+            },
+            {
+              "range": {
+                "@timestamp": {
+                  "gte": 1573344000000,
+                  "lte": 1573430400000,
+                  "format": "epoch_millis"
+                }
+              }
+            }
+          ],
+          "filter": [],
+          "should": [],
+          "must_not": []
+        }
+      },
+      "highlight": {
+        "pre_tags": ["@kibana-highlighted-field@"],
+        "post_tags": ["@/kibana-highlighted-field@"],
+        "fields": {"*": {}},
+        "fragment_size": 2147483647
+      }
+    }
+  ],
+  "meta_data": {
+    "interval": "30m",
+    "index_pattern": "elasticlogs-*",
+    "query_string": "*",
+    "dashboard": "discover",
+    "window_length": "1d",
+    "ignore_throttled": true,
+    "pre_filter_shard_size": 1,
+    "debug": false
+  }
+}

--- a/tests/parameter_sources/resources/expected-traffic.json
+++ b/tests/parameter_sources/resources/expected-traffic.json
@@ -1,0 +1,603 @@
+{
+  "body": [
+    {
+      "ignore_throttled": true,
+      "ignore_unavailable": true,
+      "index": "elasticlogs-*",
+      "preference": 5000000
+    },
+    {
+      "aggs": {
+        "filter_agg": {
+          "aggs": {
+            "2": {
+              "aggs": {
+                "3": {
+                  "geo_centroid": {
+                    "field": "nginx.access.geoip.location"
+                  }
+                }
+              },
+              "geohash_grid": {
+                "field": "nginx.access.geoip.location",
+                "precision": 2
+              }
+            }
+          },
+          "filter": {
+            "geo_bounding_box": {
+              "nginx.access.geoip.location": {
+                "bottom_right": {
+                  "lat": -90,
+                  "lon": 180
+                },
+                "top_left": {
+                  "lat": 90,
+                  "lon": -180
+                }
+              }
+            }
+          }
+        }
+      },
+      "docvalue_fields": [
+        "@timestamp"
+      ],
+      "highlight": {
+        "fields": {
+          "*": {}
+        },
+        "fragment_size": 2147483647,
+        "post_tags": [
+          "@/kibana-highlighted-field@"
+        ],
+        "pre_tags": [
+          "@kibana-highlighted-field@"
+        ]
+      },
+      "query": {
+        "bool": {
+          "filter": [],
+          "must": [
+            {
+              "match_all": {}
+            },
+            {
+              "query_string": {
+                "analyze_wildcard": true,
+                "default_field": "*",
+                "query": "*"
+              }
+            },
+            {
+              "range": {
+                "@timestamp": {
+                  "format": "epoch_millis",
+                  "gte": 1573344000000,
+                  "lte": 1573430400000
+                }
+              }
+            }
+          ],
+          "must_not": [],
+          "should": []
+        }
+      },
+      "script_fields": {},
+      "size": 0,
+      "stored_fields": [
+        "*"
+      ],
+      "version": true
+    },
+    {
+      "ignore_throttled": true,
+      "ignore_unavailable": true,
+      "index": "elasticlogs-*",
+      "preference": 5000000
+    },
+    {
+      "aggs": {
+        "2": {
+          "aggs": {
+            "3": {
+              "filters": {
+                "filters": {
+                  "200s": {
+                    "query_string": {
+                      "analyze_wildcard": true,
+                      "default_field": "*",
+                      "query": "nginx.access.response_code: [200 TO 300]"
+                    }
+                  },
+                  "300s": {
+                    "query_string": {
+                      "analyze_wildcard": true,
+                      "default_field": "*",
+                      "query": "nginx.access.response_code: [300 TO 400]"
+                    }
+                  },
+                  "400s": {
+                    "query_string": {
+                      "analyze_wildcard": true,
+                      "default_field": "*",
+                      "query": "nginx.access.response_code: [400 TO 500]"
+                    }
+                  },
+                  "500s": {
+                    "query_string": {
+                      "analyze_wildcard": true,
+                      "default_field": "*",
+                      "query": "nginx.access.response_code: [500 TO 600]"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "date_histogram": {
+            "field": "@timestamp",
+            "fixed_interval": "30m",
+            "min_doc_count": 1,
+            "time_zone": "Europe/London"
+          }
+        }
+      },
+      "docvalue_fields": [
+        "@timestamp"
+      ],
+      "highlight": {
+        "fields": {
+          "*": {}
+        },
+        "fragment_size": 2147483647,
+        "post_tags": [
+          "@/kibana-highlighted-field@"
+        ],
+        "pre_tags": [
+          "@kibana-highlighted-field@"
+        ]
+      },
+      "query": {
+        "bool": {
+          "filter": [],
+          "must": [
+            {
+              "match_all": {}
+            },
+            {
+              "query_string": {
+                "analyze_wildcard": true,
+                "default_field": "*",
+                "query": "*"
+              }
+            },
+            {
+              "range": {
+                "@timestamp": {
+                  "format": "epoch_millis",
+                  "gte": 1573344000000,
+                  "lte": 1573430400000
+                }
+              }
+            }
+          ],
+          "must_not": [],
+          "should": []
+        }
+      },
+      "script_fields": {},
+      "size": 0,
+      "stored_fields": [
+        "*"
+      ],
+      "version": true
+    },
+    {
+      "ignore_throttled": true,
+      "ignore_unavailable": true,
+      "index": "elasticlogs-*",
+      "preference": 5000000
+    },
+    {
+      "aggs": {
+        "2": {
+          "terms": {
+            "field": "nginx.access.url",
+            "order": {
+              "_count": "desc"
+            },
+            "size": 10
+          }
+        }
+      },
+      "docvalue_fields": [
+        "@timestamp"
+      ],
+      "highlight": {
+        "fields": {
+          "*": {}
+        },
+        "fragment_size": 2147483647,
+        "post_tags": [
+          "@/kibana-highlighted-field@"
+        ],
+        "pre_tags": [
+          "@kibana-highlighted-field@"
+        ]
+      },
+      "query": {
+        "bool": {
+          "filter": [],
+          "must": [
+            {
+              "match_all": {}
+            },
+            {
+              "query_string": {
+                "analyze_wildcard": true,
+                "default_field": "*",
+                "query": "*"
+              }
+            },
+            {
+              "range": {
+                "@timestamp": {
+                  "format": "epoch_millis",
+                  "gte": 1573344000000,
+                  "lte": 1573430400000
+                }
+              }
+            }
+          ],
+          "must_not": [],
+          "should": []
+        }
+      },
+      "script_fields": {},
+      "size": 0,
+      "stored_fields": [
+        "*"
+      ],
+      "version": true
+    },
+    {
+      "ignore_throttled": true,
+      "ignore_unavailable": true,
+      "index": "elasticlogs-*",
+      "preference": 5000000
+    },
+    {
+      "aggs": {
+        "2": {
+          "aggs": {
+            "1": {
+              "sum": {
+                "field": "nginx.access.body_sent.bytes"
+              }
+            }
+          },
+          "date_histogram": {
+            "field": "@timestamp",
+            "fixed_interval": "30m",
+            "min_doc_count": 1,
+            "time_zone": "Europe/London"
+          }
+        }
+      },
+      "docvalue_fields": [
+        "@timestamp"
+      ],
+      "highlight": {
+        "fields": {
+          "*": {}
+        },
+        "fragment_size": 2147483647,
+        "post_tags": [
+          "@/kibana-highlighted-field@"
+        ],
+        "pre_tags": [
+          "@kibana-highlighted-field@"
+        ]
+      },
+      "query": {
+        "bool": {
+          "filter": [],
+          "must": [
+            {
+              "match_all": {}
+            },
+            {
+              "query_string": {
+                "analyze_wildcard": true,
+                "default_field": "*",
+                "query": "*"
+              }
+            },
+            {
+              "range": {
+                "@timestamp": {
+                  "format": "epoch_millis",
+                  "gte": 1573344000000,
+                  "lte": 1573430400000
+                }
+              }
+            }
+          ],
+          "must_not": [],
+          "should": []
+        }
+      },
+      "script_fields": {},
+      "size": 0,
+      "stored_fields": [
+        "*"
+      ],
+      "version": true
+    },
+    {
+      "ignore_throttled": true,
+      "ignore_unavailable": true,
+      "index": "elasticlogs-*",
+      "preference": 5000000
+    },
+    {
+      "aggs": {
+        "2": {
+          "aggs": {
+            "3": {
+              "terms": {
+                "field": "nginx.access.user_agent.major",
+                "order": {
+                  "_count": "desc"
+                },
+                "size": 5
+              }
+            }
+          },
+          "terms": {
+            "field": "nginx.access.user_agent.name",
+            "order": {
+              "_count": "desc"
+            },
+            "size": 5
+          }
+        }
+      },
+      "docvalue_fields": [
+        "@timestamp"
+      ],
+      "highlight": {
+        "fields": {
+          "*": {}
+        },
+        "fragment_size": 2147483647,
+        "post_tags": [
+          "@/kibana-highlighted-field@"
+        ],
+        "pre_tags": [
+          "@kibana-highlighted-field@"
+        ]
+      },
+      "query": {
+        "bool": {
+          "filter": [],
+          "must": [
+            {
+              "query_string": {
+                "analyze_wildcard": true,
+                "default_field": "*",
+                "query": "*"
+              }
+            },
+            {
+              "query_string": {
+                "analyze_wildcard": true,
+                "default_field": "*",
+                "query": "*"
+              }
+            },
+            {
+              "range": {
+                "@timestamp": {
+                  "format": "epoch_millis",
+                  "gte": 1573344000000,
+                  "lte": 1573430400000
+                }
+              }
+            }
+          ],
+          "must_not": [],
+          "should": []
+        }
+      },
+      "script_fields": {},
+      "size": 0,
+      "stored_fields": [
+        "*"
+      ],
+      "version": true
+    },
+    {
+      "ignore_throttled": true,
+      "ignore_unavailable": true,
+      "index": "elasticlogs-*",
+      "preference": 5000000
+    },
+    {
+      "aggs": {
+        "2": {
+          "aggs": {
+            "3": {
+              "terms": {
+                "field": "nginx.access.user_agent.os_major",
+                "order": {
+                  "_count": "desc"
+                },
+                "size": 5
+              }
+            }
+          },
+          "terms": {
+            "field": "nginx.access.user_agent.os_name",
+            "order": {
+              "_count": "desc"
+            },
+            "size": 5
+          }
+        }
+      },
+      "docvalue_fields": [
+        "@timestamp"
+      ],
+      "highlight": {
+        "fields": {
+          "*": {}
+        },
+        "fragment_size": 2147483647,
+        "post_tags": [
+          "@/kibana-highlighted-field@"
+        ],
+        "pre_tags": [
+          "@kibana-highlighted-field@"
+        ]
+      },
+      "query": {
+        "bool": {
+          "filter": [],
+          "must": [
+            {
+              "query_string": {
+                "analyze_wildcard": true,
+                "default_field": "*",
+                "query": "*"
+              }
+            },
+            {
+              "query_string": {
+                "analyze_wildcard": true,
+                "default_field": "*",
+                "query": "*"
+              }
+            },
+            {
+              "range": {
+                "@timestamp": {
+                  "format": "epoch_millis",
+                  "gte": 1573344000000,
+                  "lte": 1573430400000
+                }
+              }
+            }
+          ],
+          "must_not": [],
+          "should": []
+        }
+      },
+      "script_fields": {},
+      "size": 0,
+      "stored_fields": [
+        "*"
+      ],
+      "version": true
+    },
+    {
+      "ignore_throttled": true,
+      "ignore_unavailable": true,
+      "index": "elasticlogs-*",
+      "preference": 5000000
+    },
+    {
+      "_source": {
+        "excludes": []
+      },
+      "aggs": {
+        "2": {
+          "aggs": {
+            "3": {
+              "terms": {
+                "field": "nginx.access.response_code",
+                "order": {
+                  "_count": "desc"
+                },
+                "size": 10
+              }
+            }
+          },
+          "date_histogram": {
+            "field": "@timestamp",
+            "fixed_interval": "30m",
+            "min_doc_count": 1,
+            "time_zone": "Europe/London"
+          }
+        }
+      },
+      "docvalue_fields": [
+        "@timestamp"
+      ],
+      "highlight": {
+        "fields": {
+          "*": {}
+        },
+        "fragment_size": 2147483647,
+        "post_tags": [
+          "@/kibana-highlighted-field@"
+        ],
+        "pre_tags": [
+          "@kibana-highlighted-field@"
+        ]
+      },
+      "query": {
+        "bool": {
+          "filter": [],
+          "must": [
+            {
+              "match_all": {}
+            },
+            {
+              "query_string": {
+                "analyze_wildcard": true,
+                "default_field": "*",
+                "query": "nginx.access.response_code: [400 TO 600]"
+              }
+            },
+            {
+              "query_string": {
+                "analyze_wildcard": true,
+                "default_field": "*",
+                "query": "*"
+              }
+            },
+            {
+              "range": {
+                "@timestamp": {
+                  "format": "epoch_millis",
+                  "gte": 1573344000000,
+                  "lte": 1573430400000
+                }
+              }
+            }
+          ],
+          "must_not": [],
+          "should": []
+        }
+      },
+      "script_fields": {},
+      "size": 0,
+      "stored_fields": [
+        "*"
+      ],
+      "version": true
+    }
+  ],
+  "meta_data": {
+    "dashboard": "traffic",
+    "debug": false,
+    "ignore_throttled": true,
+    "index_pattern": "elasticlogs-*",
+    "interval": "30m",
+    "pre_filter_shard_size": 1,
+    "query_string": "*",
+    "window_length": "1d"
+  }
+}


### PR DESCRIPTION
With this commit we switch from the deprecated `interval` aggregation to
the `fixed_interval` aggregation. We also improve the documentation of
the function that determines the interval based on the queried date
range and add more tests.

Closes #48 