### PR TITLE
Make index_pattern mandatory

### DIFF
--- a/eventdata/parameter_sources/elasticlogs_kibana_source.py
+++ b/eventdata/parameter_sources/elasticlogs_kibana_source.py
@@ -58,7 +58,7 @@ class ElasticlogsKibanaSource:
         "dashboard"             -   String indicating which dashboard to simulate. Options are 'traffic', 'content_issues' and 'discover'.
         "query_string"          -   String indicating file to load or list of strings indicating actual query parameters to randomize during benchmarking. Defaults 
                                     to ["*"], If a list has been specified, a random value will be selected.
-        "index_pattern"         -   String or list of strings representing the index pattern to query. Defaults to 'elasticlogs-*'. If a list has 
+        "index_pattern"         -   String or list of strings representing the index pattern to query. If a list has
                                     been specified, a random value will be selected.
         "window_end"            -   Specification of aggregation window end or period within which it should end. If one single value is specified, 
                                     that will be used to anchor the window. If two values are given in a comma separated list, the end of the window
@@ -83,7 +83,7 @@ class ElasticlogsKibanaSource:
     def __init__(self, track, params, **kwargs):
         self._params = params
         self._indices = track.indices
-        self._index_pattern = params.get("index_pattern", "elasticlogs-*")
+        self._index_pattern = params["index_pattern"]
         self._query_string_list = ["*"]
         self._dashboard = params["dashboard"]
         self._discover_size = params.get("discover_size", 500)

--- a/eventdata/runners/deleteindex_runner.py
+++ b/eventdata/runners/deleteindex_runner.py
@@ -29,7 +29,7 @@ def deleteindex(es, params):
     :type params: dict
 
         "index_pattern"        - Mandatory.
-                                 Specifies the index pattern to delete. Defaults to 'elasticlogs-*'
+                                 Specifies the index pattern to delete.
         "max_indices"          - Optional.
                                  int specifying how many rolled over indices to retain at max.
                                  The elibigle indices need to satisfy `index-pattern`.
@@ -60,7 +60,7 @@ def deleteindex(es, params):
                     return None
         return None
 
-    index_pattern = params.get('index_pattern', 'elasticlogs-*')
+    index_pattern = params['index_pattern']
     max_indices = params.get('max_indices', None)
     suffix_separator = params.get('suffix_separator', '-')
 

--- a/eventdata/runners/indicesstats_runner.py
+++ b/eventdata/runners/indicesstats_runner.py
@@ -28,13 +28,9 @@ def indicesstats(es, params):
     Retrieves index stats for an index or index pattern.
 
     It expects the parameter hash to contain the following keys:
-        "index_pattern" - Index pattern that storage statistics are retrieved for. Defaults to "elasticlogs-*".
+        "index_pattern" - Index pattern that storage statistics are retrieved for.
     """
-    if 'index_pattern' not in params:
-        index_pattern = 'elasticlogs-*'
-    else:
-        index_pattern = params['index_pattern']
-
+    index_pattern = params['index_pattern']
     response = {
         "weight": 1,
         "unit": "ops",

--- a/tests/parameter_sources/elasticlogs_kibana_source_test.py
+++ b/tests/parameter_sources/elasticlogs_kibana_source_test.py
@@ -37,7 +37,8 @@ def test_create_discover(time):
     time.return_value = 5000
 
     param_source = ElasticlogsKibanaSource(track=StaticTrack(), params={
-        "dashboard": "discover"
+        "dashboard": "discover",
+        "index_pattern": "elasticlogs-*"
     }, utcnow=lambda: datetime(year=2019, month=11, day=11))
     response = param_source.params()
 
@@ -49,7 +50,8 @@ def test_create_content_issues_dashboard(time):
     time.return_value = 5000
 
     param_source = ElasticlogsKibanaSource(track=StaticTrack(), params={
-        "dashboard": "content_issues"
+        "dashboard": "content_issues",
+        "index_pattern": "elasticlogs-*"
     }, utcnow=lambda: datetime(year=2019, month=11, day=11))
     response = param_source.params()
 
@@ -61,7 +63,8 @@ def test_create_traffic_dashboard(time):
     time.return_value = 5000
 
     param_source = ElasticlogsKibanaSource(track=StaticTrack(), params={
-        "dashboard": "traffic"
+        "dashboard": "traffic",
+        "index_pattern": "elasticlogs-*"
     }, utcnow=lambda: datetime(year=2019, month=11, day=11))
     response = param_source.params()
 
@@ -70,14 +73,21 @@ def test_create_traffic_dashboard(time):
 
 def test_dashboard_is_mandatory():
     with pytest.raises(KeyError) as ex:
-        ElasticlogsKibanaSource(track=StaticTrack(), params={})
+        ElasticlogsKibanaSource(track=StaticTrack(), params={"index_pattern": "elasticlogs*"})
 
     assert "'dashboard'" == str(ex.value)
 
 
+def test_index_pattern_is_mandatory():
+    with pytest.raises(KeyError) as ex:
+        ElasticlogsKibanaSource(track=StaticTrack(), params={"dashboard": "traffic"})
+
+    assert "'index_pattern'" == str(ex.value)
+
+
 def test_invalid_dashboard_raises_error():
     with pytest.raises(ConfigurationError) as ex:
-        ElasticlogsKibanaSource(track=StaticTrack(), params={"dashboard": "unknown"})
+        ElasticlogsKibanaSource(track=StaticTrack(), params={"dashboard": "unknown", "index_pattern": "elasticlogs*"})
 
     assert "Unknown dashboard [unknown]. Must be one of ['traffic', 'content_issues', 'discover']." == str(ex.value)
 


### PR DESCRIPTION
With this commit we turn `index_pattern` into a mandatory parameter in
all places where it was still optional. This avoids accidental mistakes
and ensures that the intended index pattern is used.