### PR TITLE
Make query index pattern overridable

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Note: In general, track parameters are only defined for a subset of the challeng
 | --------- | ----------- | ---- | ------------- |
 | `record_raw_event_size` | Adds a new field `_raw_event_size` to the index which contains the size of the raw logging event in bytes. | `bool` | `False` |
 | `query_index_prefix` | Start of the index name(s) used in queries for this track. | `str` | `elasticlogs_q` |
+| `query_index_pattern` | Index pattern used in queries for this track. | `str` | `$query_index_prefix + "-*"` |
 | `verbose` | Emits additional debug logs. Enable this only when testing changes but not when running regular benchmarks as this influences performance negatively. | `bool` | `False` |
 
 Note: It is recommended to store any track parameters in a json file and pass them to Rally using `--track-params=./params-file.json`. 

--- a/eventdata/track.json
+++ b/eventdata/track.json
@@ -4,7 +4,7 @@
 {% set p_record_raw_event_size = record_raw_event_size | default(False) | tojson %}
 {% set p_index_prefix = index_prefix | default("elasticlogs") %}
 {% set p_query_index_prefix = query_index_prefix | default(p_index_prefix ~ "_q") %}
-{% set p_query_index_pattern = p_query_index_prefix ~ "-*" %}
+{% set p_query_index_pattern = query_index_pattern | default(p_query_index_prefix ~ "-*") %}
 {% set p_query_index_write_alias = p_query_index_prefix ~ "_write" %}
 {% set p_verbose = verbose | default(False) | tojson %}
 


### PR DESCRIPTION
With this commit we don't only make the query index prefix overridable
but also the actual index pattern (with the track parameter
`query_index_pattern`.