### PR TITLE
Remove obsolete create-index tasks

### DIFF
--- a/eventdata/challenges/bulk-update.json
+++ b/eventdata/challenges/bulk-update.json
@@ -1,8 +1,6 @@
 {% set p_bulk_indexing_clients = (bulk_indexing_clients | default(20)) %}
 {% set p_iterations = bulk_indexing_iterations | default(1000000) %}
 {% set p_iterations_per_client = (p_iterations / p_bulk_indexing_clients) | int %}
-{% set number_of_replicas = (number_of_replicas | default(1)) %}
-{% set number_of_shards = (number_of_shards | default(2)) %}
 {
   "name": "bulk-update",
   "default": false,
@@ -20,32 +18,6 @@
     },
     {
       "operation": "create-index-template"
-    },
-    {
-      "operation": {
-        "operation-type": "create-index",
-        "index": "elasticlogs",
-        "body": {
-          "settings": {
-              {% if index_refresh_interval is defined %}
-              "index.refresh_interval": {{ index_refresh_interval | int }},
-              {% endif %}
-              "index.number_of_replicas": {{ number_of_replicas }},
-              "index.number_of_shards": {{ number_of_shards }}
-          }
-        }
-      }
-    },
-    {
-      "name": "check-cluster-health",
-      "operation": {
-        "operation-type": "cluster-health",
-        "index": "elasticlogs",
-        "request-params": {
-          "wait_for_status": "{{cluster_health | default('green')}}",
-          "wait_for_no_relocating_shards": "true"
-        }
-      }
     },
     {
       "warmup-iterations": 20,

--- a/eventdata/challenges/document_id_benchmark.json
+++ b/eventdata/challenges/document_id_benchmark.json
@@ -31,13 +31,6 @@
       }
     },
     {
-      "name": "create-index-elasticlogs-warmup",
-      "operation": {
-        "operation-type": "create-index",
-        "index": "elasticlogs-warmup"
-      }
-    },
-    {
       "name": "index-append-1000-elasticlogs-warmup",
       "operation": {
         "operation-type": "bulk",
@@ -68,13 +61,6 @@
       "name": "delete-index-elasticlogs-{{ id['desc'] }}",
       "operation": {
         "operation-type": "delete-index",
-        "index": "elasticlogs-{{ id['desc'] }}"
-      }
-    },
-    {
-      "name": "create-index-elasticlogs-{{ id['desc'] }}",
-      "operation": {
-        "operation-type": "create-index",
         "index": "elasticlogs-{{ id['desc'] }}"
       }
     },
@@ -133,13 +119,6 @@
       "name": "delete-index-elasticlogs-{{ id['desc'] }}",
       "operation": {
         "operation-type": "delete-index",
-        "index": "elasticlogs-{{ id['desc'] }}"
-      }
-    },
-    {
-      "name": "create-index-elasticlogs-{{ id['desc'] }}",
-      "operation": {
-        "operation-type": "create-index",
         "index": "elasticlogs-{{ id['desc'] }}"
       }
     },

--- a/eventdata/challenges/frozen.json
+++ b/eventdata/challenges/frozen.json
@@ -21,12 +21,6 @@
       }
     },
     {
-      "operation": {
-        "operation-type": "create-index",
-        "index": "elasticlogs"
-      }
-    },
-    {
       "name": "index-append-1000-datagen",
       "operation": {
         "name": "index-append-1000-datagen-20180102",

--- a/eventdata/challenges/large-shard-sizing.json
+++ b/eventdata/challenges/large-shard-sizing.json
@@ -30,12 +30,6 @@
         }
       }
     },
-    {
-      "operation": {
-        "operation-type": "create-index",
-        "index": "elasticlogs-auto"
-      }
-    },
     {% for p_multiple in range(1, 13) %}
     {% set p_size = p_multiple * 25 %}
     {
@@ -177,13 +171,6 @@
         "settings": {
           "index.number_of_shards": {{ shard_count | default(1) }}
         }
-      }
-    },
-    {
-      "name": "create-index-elasticlogs-{{ id_type }}",
-      "operation": {
-        "operation-type": "create-index",
-        "index": "elasticlogs-{{ id_type }}"
       }
     },
     {

--- a/eventdata/challenges/shard-size-on-disk.json
+++ b/eventdata/challenges/shard-size-on-disk.json
@@ -18,12 +18,6 @@
     {
       "operation": "create-index-template"
     },
-    {
-      "operation": {
-        "operation-type": "create-index",
-        "index": "elasticlogs"
-      }
-    },
     {% set comma = joiner() %}
     {% for n in range(1,51) %}
     {{comma()}}

--- a/eventdata/challenges/shard-sizing.json
+++ b/eventdata/challenges/shard-sizing.json
@@ -20,12 +20,6 @@
     {
       "operation": "create-index-template"
     },
-    {
-      "operation": {
-        "operation-type": "create-index",
-        "index": "elasticlogs"
-      }
-    },
     {% for n in range(1, p_shard_sizing_iterations) %}
     {
       "name": "index-append-1000-shard-sizing-iteration-{{n}}",


### PR DESCRIPTION
This track defines an index template that defines common settings. When
bulk-indexing, indices will be automatically created based on this index
template. Therefore, explicit invocation of the create index API are
obsolete (unless they contain additional instructions such as creating
an alias).

With this commit we remove all these tasks and also related tasks (e.g.
it is not necessary to check for cluster health based on a specific
index if that index is not present yet).