### PR TITLE
Avoid more time-consuming calls

### DIFF
--- a/eventdata/parameter_sources/elasticlogs_bulk_source.py
+++ b/eventdata/parameter_sources/elasticlogs_bulk_source.py
@@ -144,6 +144,7 @@ class ElasticlogsBulkSource:
     def params(self):
         # Build bulk array
         bulk_array = []
+        self._randomevent.start_bulk(self._bulk_size)
         for x in range(0, self._bulk_size):
             try:
                 evt, idx, typ = self._randomevent.generate_event()

--- a/eventdata/parameter_sources/randomevent.py
+++ b/eventdata/parameter_sources/randomevent.py
@@ -18,6 +18,7 @@
 
 import datetime
 import gzip
+import itertools
 import json
 import os
 import random
@@ -296,7 +297,7 @@ class RandomEvent:
         self.remaining_days = self.total_days
         self.record_raw_event_size = params.get("record_raw_event_size", False)
         self._offset = 0
-        self._web_host_index = 0
+        self._web_host = itertools.cycle([1, 2, 3])
         self._timestruct = None
         self._index_name = None
         self._time_interval_current_bulk = 0
@@ -335,9 +336,7 @@ class RandomEvent:
         self._referrer.add_fields(event)
         self._request.add_fields(event)
 
-        # set host name
-        self._web_host_index = (self._web_host_index + 1) % 3
-        event["hostname"] = "web-%s-%s.elastic.co" % (event["geoip_continent_code"], self._web_host_index)
+        event["hostname"] = "web-%s-%s.elastic.co" % (event["geoip_continent_code"], next(self._web_host))
 
         if self.record_raw_event_size or self.daily_logging_volume:
             # determine the raw event size (as if this were contained in nginx log file). We do not bother to

--- a/tests/parameter_sources/elasticlogs_bulk_source_test.py
+++ b/tests/parameter_sources/elasticlogs_bulk_source_test.py
@@ -26,6 +26,9 @@ class StaticEventGenerator:
         self.doc = doc
         self.at_most = at_most
 
+    def start_bulk(self, bulk_size):
+        pass
+
     def generate_event(self):
         if self.at_most == 0:
             raise StopIteration()

--- a/tests/parameter_sources/randomevent_test.py
+++ b/tests/parameter_sources/randomevent_test.py
@@ -72,6 +72,7 @@ def test_random_event_no_event_size_by_default():
         referrer=StaticReferrer,
         request=StaticRequest)
 
+    e.start_bulk(1)
     raw_doc, index, doc_type = e.generate_event()
 
     doc = json.loads(raw_doc)
@@ -93,6 +94,7 @@ def test_random_event_with_event_size():
         referrer=StaticReferrer,
         request=StaticRequest)
 
+    e.start_bulk(1)
     raw_doc, index, doc_type = e.generate_event()
 
     doc = json.loads(raw_doc)
@@ -118,6 +120,7 @@ def test_random_events_with_daily_logging_volume():
 
     assert e.percent_completed is None
 
+    e.start_bulk(15)
     # 5 events fit into one kilobyte
     for i in range(5):
         doc, index, _ = e.generate_event()
@@ -150,6 +153,7 @@ def test_random_events_with_daily_logging_volume_and_maximum_days():
 
     assert e.percent_completed == 0.0
 
+    e.start_bulk(5)
     # 5 events fit into one kilobyte
     for i in range(5):
         doc, index, _ = e.generate_event()
@@ -157,6 +161,7 @@ def test_random_events_with_daily_logging_volume_and_maximum_days():
 
     assert e.percent_completed == 0.5
 
+    e.start_bulk(6)
     for i in range(5):
         doc, index, _ = e.generate_event()
         assert index == "logs-20190106"

--- a/tests/parameter_sources/timeutils_test.py
+++ b/tests/parameter_sources/timeutils_test.py
@@ -41,6 +41,7 @@ def test_generate_interval_from_now():
     # first generated timestamp will be one (clock) invocation after the original start
     assert g.next_timestamp() == {
         "iso": "2019-01-05T15:00:05.000Z",
+        "iso_prefix": "2019-01-05T15:00:05",
         "yyyy": "2019",
         "yy": "19",
         "mm": "01",
@@ -50,6 +51,7 @@ def test_generate_interval_from_now():
 
     assert g.next_timestamp() == {
         "iso": "2019-01-05T15:00:10.000Z",
+        "iso_prefix": "2019-01-05T15:00:10",
         "yyyy": "2019",
         "yy": "19",
         "mm": "01",
@@ -59,6 +61,7 @@ def test_generate_interval_from_now():
 
     assert g.next_timestamp() == {
         "iso": "2019-01-05T15:00:15.000Z",
+        "iso_prefix": "2019-01-05T15:00:15",
         "yyyy": "2019",
         "yy": "19",
         "mm": "01",
@@ -77,6 +80,7 @@ def test_generate_interval_from_fixed_starting_point():
 
     assert g.next_timestamp() == {
         "iso": "2018-05-01T00:59:59.000Z",
+        "iso_prefix": "2018-05-01T00:59:59",
         "yyyy": "2018",
         "yy": "18",
         "mm": "05",
@@ -86,6 +90,7 @@ def test_generate_interval_from_fixed_starting_point():
 
     assert g.next_timestamp() == {
         "iso": "2018-05-01T01:00:02.000Z",
+        "iso_prefix": "2018-05-01T01:00:02",
         "yyyy": "2018",
         "yy": "18",
         "mm": "05",
@@ -94,6 +99,7 @@ def test_generate_interval_from_fixed_starting_point():
     }
     assert g.next_timestamp() == {
         "iso": "2018-05-01T01:00:05.000Z",
+        "iso_prefix": "2018-05-01T01:00:05",
         "yyyy": "2018",
         "yy": "18",
         "mm": "05",
@@ -113,6 +119,7 @@ def test_generate_interval_from_fixed_starting_point_with_offset():
 
     assert g.next_timestamp() == {
         "iso": "2018-05-11T00:59:59.000Z",
+        "iso_prefix": "2018-05-11T00:59:59",
         "yyyy": "2018",
         "yy": "18",
         "mm": "05",
@@ -122,6 +129,7 @@ def test_generate_interval_from_fixed_starting_point_with_offset():
 
     assert g.next_timestamp() == {
         "iso": "2018-05-11T01:00:02.000Z",
+        "iso_prefix": "2018-05-11T01:00:02",
         "yyyy": "2018",
         "yy": "18",
         "mm": "05",
@@ -130,6 +138,7 @@ def test_generate_interval_from_fixed_starting_point_with_offset():
     }
     assert g.next_timestamp() == {
         "iso": "2018-05-11T01:00:05.000Z",
+        "iso_prefix": "2018-05-11T01:00:05",
         "yyyy": "2018",
         "yy": "18",
         "mm": "05",
@@ -148,6 +157,7 @@ def test_generate_interval_and_skip():
 
     assert g.next_timestamp() == {
         "iso": "2018-05-01T00:59:59.000Z",
+        "iso_prefix": "2018-05-01T00:59:59",
         "yyyy": "2018",
         "yy": "18",
         "mm": "05",
@@ -157,6 +167,7 @@ def test_generate_interval_and_skip():
 
     assert g.next_timestamp() == {
         "iso": "2018-05-01T01:00:02.000Z",
+        "iso_prefix": "2018-05-01T01:00:02",
         "yyyy": "2018",
         "yy": "18",
         "mm": "05",
@@ -168,6 +179,7 @@ def test_generate_interval_and_skip():
 
     assert g.next_timestamp() == {
         "iso": "2018-05-02T00:59:59.000Z",
+        "iso_prefix": "2018-05-02T00:59:59",
         "yyyy": "2018",
         "yy": "18",
         "mm": "05",
@@ -177,11 +189,61 @@ def test_generate_interval_and_skip():
 
     assert g.next_timestamp() == {
         "iso": "2018-05-02T01:00:02.000Z",
+        "iso_prefix": "2018-05-02T01:00:02",
         "yyyy": "2018",
         "yy": "18",
         "mm": "05",
         "dd": "02",
         "hh": "01"
+    }
+
+
+def test_simulate_ticks():
+    clock = ReproducibleClock(start=datetime.datetime(year=2019, month=1, day=5, hour=15),
+                              delta=datetime.timedelta(seconds=1))
+
+    g = TimestampStructGenerator(starting_point="2018-05-01:00:59:56",
+                                 acceleration_factor=3.0,
+                                 utcnow=clock)
+
+    assert g.next_timestamp() == {
+        "iso": "2018-05-01T00:59:59.000Z",
+        "iso_prefix": "2018-05-01T00:59:59",
+        "yyyy": "2018",
+        "yy": "18",
+        "mm": "05",
+        "dd": "01",
+        "hh": "00"
+    }
+
+    assert g.simulate_tick(micros=1.0) == {
+        "iso": "2018-05-01T00:59:59.001Z",
+        "iso_prefix": "2018-05-01T00:59:59",
+        "yyyy": "2018",
+        "yy": "18",
+        "mm": "05",
+        "dd": "01",
+        "hh": "00"
+    }
+
+    assert g.simulate_tick(micros=0.1) == {
+        "iso": "2018-05-01T00:59:59.001Z",
+        "iso_prefix": "2018-05-01T00:59:59",
+        "yyyy": "2018",
+        "yy": "18",
+        "mm": "05",
+        "dd": "01",
+        "hh": "00"
+    }
+
+    assert g.simulate_tick(micros=10.0) == {
+        "iso": "2018-05-01T00:59:59.011Z",
+        "iso_prefix": "2018-05-01T00:59:59",
+        "yyyy": "2018",
+        "yy": "18",
+        "mm": "05",
+        "dd": "01",
+        "hh": "00"
     }
 
 


### PR DESCRIPTION
With this commit we reduce usage of two time-consuming methods on the hot code
path: generating random numbers and determining the current timestamp. This also
changes behavior slightly:

* The `hostname` field will vary host names from 1 - 3 in a regular pattern
instead of randomly (however, as the host name is e.g. `web-EU-1.elastic.co` and
only the number changes non-randomly we deem this change ok)
* The `offset` will change be more realistic now: Before it changed randomly and
now the offset increases by the average event size up to a certain maximum.
* The current `@timestamp` will be retrieved only once per bulk. For documents
within a bulk we'll advance the microsecond portion by `1 / bulk size`
microseconds.

We've measured the performance impact of this change by stubbing out
Elasticsearch with nginx and running the `index-logs-fixed-daily-volume`
challenge with the following track parameters:

* `bulk_size`: 20000
* `bulk_indexing_clients`: 16
* `number_of_days`: 1
* `daily_logging_volume`: "20GB"

We have measured the following median indexing throughput in our test
environment:

* baseline (master): 153476 docs/s
* Using a deterministic `hostname` and `offset`: 174371 docs/s
* All three measures together: 222611 docs/s

This means we improve the maximum achievable indexing throughput by 45% in this
configuration.