### PR TITLE
Use discover query in discover operation

### DIFF
--- a/eventdata/operations/querying.json
+++ b/eventdata/operations/querying.json
@@ -179,7 +179,7 @@
   "operation-type": "kibana",
   "param-source": "elasticlogs_kibana",
   "debug": {{p_verbose}},
-  "dashboard": "traffic",
+  "dashboard": "discover",
   "index_pattern": "{{p_query_index_pattern}}",
   "query_string": ["*"],
   "window_end": "now",


### PR DESCRIPTION
With this commit we change the dashboard to "discover" for the operation
named `current-kibana-discover_30m`. The name suggests that we intend to
use the discover functionality here but previously it has used the
traffic dashboard instead.