### PR TITLE
Lower windows for queries

### DIFF
--- a/eventdata/challenges/daily-log-volume-index-and-query.json
+++ b/eventdata/challenges/daily-log-volume-index-and-query.json
@@ -82,7 +82,7 @@
             }
           },
           {
-            "name": "traffic-dashboard-50%-{{utilization_task_suffix}}",
+            "name": "traffic-dashboard-25%-{{utilization_task_suffix}}",
             "operation": {
               "operation-type": "kibana",
               "param-source": "elasticlogs_kibana",
@@ -91,10 +91,10 @@
               "index_pattern": "elasticlogs-*",
               "query_string": "query_string_lists/country_code_query_strings.json",
               "window_end": "END",
-              "window_length": "50%"
+              "window_length": "25%"
             },
             "clients": 1,
-            "target-interval": {{ query1_target_interval | default(30) | int }},
+            "target-interval": {{ query1_target_interval | default(90) | int }},
             "meta": {
               "querying": "yes",
               "query_type": "relative",
@@ -124,7 +124,7 @@
             "schedule": "poisson"
           },
           {
-            "name": "content_issues-dashboard-50%-{{utilization_task_suffix}}",
+            "name": "content_issues-dashboard-25%-{{utilization_task_suffix}}",
             "#COMMENT": "Looks only for 404s about 1-1.5% of data",
             "operation": {
               "operation-type": "kibana",
@@ -134,10 +134,10 @@
               "index_pattern": "elasticlogs-*",
               "query_string": ["*"],
               "window_end": "END",
-              "window_length": "50%"
+              "window_length": "25%"
             },
             "clients": 1,
-            "target-interval": {{ query3_target_interval | default(30) | int }},
+            "target-interval": {{ query3_target_interval | default(45) | int }},
             "meta": {
               "querying": "yes",
               "query_type": "relative",


### PR DESCRIPTION
with this commit we lower the time window for dashboard queries from 50%
to 25% and also lower their target throughput to better match real world
use cases.