### PR TITLE
Expose starting_point for daily indexing

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,13 +228,14 @@ The table below shows the track parameters that can be adjusted along with defau
 
 This challenge indexes a fixed (raw) logging volume of logs per day into daily indices. This challenge will complete tasks as quickly as possible and won't take the amount of days specified in the number_of_days field.  The table below shows the track parameters that can be adjusted along with default values:
 
-| Parameter               | Explanation                                                                                                                            | Type  | Default Value |
-| ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------- | ----- | ------------- |
-| `bulk_indexing_clients` | Number of bulk indexing clients/connections                                                                                            | `int` | `8`           |
+| Parameter               | Explanation                                                                                                                            | Type  | Default Value         |
+| ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------- | ----- | --------------------- |
+| `bulk_indexing_clients` | Number of bulk indexing clients/connections                                                                                            | `int` | `8`                   |
 | `bulk_size`             | Number of documents to send per bulk                                                                                                   | `int` | `1000`                |
-| `daily_logging_volume`  | The raw logging volume. Supported units are bytes (without any unit), `kb`, `MB` and `GB`). For the value, only integers are allowed.  | `str` | `100GB`       |
-| `number_of_days`        | The number of simulated days for which data should be generated.                                                                                 | `int` | `24`          |
-| `number_of_shards`      | Number of primary shards                                                                                                               | `int` | `3`           |
+| `daily_logging_volume`  | The raw logging volume. Supported units are bytes (without any unit), `kb`, `MB` and `GB`). For the value, only integers are allowed.  | `str` | `100GB`               |
+| `starting_point`        | The first timestamp for which logs should be generated.                                                                                | `str` | `2018-05-01:00:00:00` |
+| `number_of_days`        | The number of simulated days for which data should be generated.                                                                       | `int` | `24`                  |
+| `number_of_shards`      | Number of primary shards                                                                                                               | `int` | `3`                   |
 
 ### index-and-query-logs-fixed-daily-volume
 

--- a/eventdata/challenges/daily-log-volume-index.json
+++ b/eventdata/challenges/daily-log-volume-index.json
@@ -1,5 +1,6 @@
 {% set p_bulk_indexing_clients = (bulk_indexing_clients | default(8)) %}
 {% set p_bulk_size = (bulk_size | default(1000)) %}
+{% set p_starting_point = (starting_point | default("2018-05-01:00:00:00")) %}
 {% set p_number_of_days = (number_of_days | default(24)) %}
 {% set p_daily_logging_volume = (daily_logging_volume | default("100GB")) %}
 
@@ -35,7 +36,7 @@
         "operation-type": "bulk",
         "param-source": "elasticlogs_bulk",
         "index": "elasticlogs-<yyyy>-<mm>-<dd>",
-        "starting_point": "2018-05-01:00:00:00",
+        "starting_point": "{{p_starting_point}}",
         "bulk-size": {{p_bulk_size}},
         "daily_logging_volume": "{{p_daily_logging_volume}}",
         "number_of_days": {{p_number_of_days}},


### PR DESCRIPTION
With this commit we expose a new track parameter `starting_point` for
the challenge `index-logs-fixed-daily-volume`. It has previously assumed
a certain date but for consistency with
`index-and-query-logs-fixed-daily-volume` we now expose a track
parameter for this date.