### PR TITLE
Expose additional meta-data for queries

### DIFF
--- a/eventdata/challenges/daily-log-volume-index-and-query.json
+++ b/eventdata/challenges/daily-log-volume-index-and-query.json
@@ -98,7 +98,9 @@
             "meta": {
               "querying": "yes",
               "query_type": "relative",
-              "utilization": {{ utilization }}
+              "utilization": {{ utilization }},
+              "dashboard": "traffic",
+              "window_length": "25%"
             },
             "schedule": "poisson"
           },
@@ -119,7 +121,9 @@
             "meta": {
               "querying": "yes",
               "query_type": "relative",
-              "utilization": {{ utilization }}
+              "utilization": {{ utilization }},
+              "dashboard": "discover",
+              "window_length": "30m"
             },
             "schedule": "poisson"
           },
@@ -141,7 +145,9 @@
             "meta": {
               "querying": "yes",
               "query_type": "relative",
-              "utilization": {{ utilization }}
+              "utilization": {{ utilization }},
+              "dashboard": "content_issues",
+              "window_length": "25%"
             },
             "schedule": "poisson"
           }


### PR DESCRIPTION
With this commit we expose two additional meta-data fields (`dashboard`
and `window_length`) for the `index-and-query-logs-fixed-daily-volume`
challenge. Meta-data are also propagated to Rally's results index and
can be thus used for creating more useful charts.