### PR TITLE
Adapt response handling in async runners

### DIFF
--- a/eventdata/runners/deleteindex_runner.py
+++ b/eventdata/runners/deleteindex_runner.py
@@ -66,7 +66,8 @@ async def deleteindex_async(es, params):
     suffix_separator = params.get('suffix_separator', '-')
 
     if max_indices:
-        indices = await es.cat.indices(h='index').split("\n")
+        response = await es.cat.indices(h='index')
+        indices = response.decode("utf-8").split("\n")
         indices_by_suffix = {get_suffix(idx, suffix_separator): idx
             for idx in indices
             if fnmatch(idx, index_pattern) and

--- a/eventdata/runners/deleteindex_runner.py
+++ b/eventdata/runners/deleteindex_runner.py
@@ -61,12 +61,12 @@ async def deleteindex_async(es, params):
                     return None
         return None
 
-    index_pattern = params['index_pattern']
-    max_indices = params.get('max_indices', None)
-    suffix_separator = params.get('suffix_separator', '-')
+    index_pattern = params["index_pattern"]
+    max_indices = params.get("max_indices", None)
+    suffix_separator = params.get("suffix_separator", "-")
 
     if max_indices:
-        response = await es.cat.indices(h='index')
+        response = await es.cat.indices(h="index")
         indices = response.decode("utf-8").split("\n")
         indices_by_suffix = {get_suffix(idx, suffix_separator): idx
             for idx in indices

--- a/eventdata/runners/nodestorage_runner.py
+++ b/eventdata/runners/nodestorage_runner.py
@@ -39,6 +39,7 @@ async def nodestorage_async(es, params):
     try:
         # get number of data nodes
         node_role_list = await es.cat.nodes(h="node.role")
+        node_role_list = node_role_list.decode("utf-8")
 
         data_node_count = 0
 


### PR DESCRIPTION
With this commit we adapt the response handling in async runners by
properly converting them from raw bytes to strings.

Relates elastic/rally#944