### PR TITLE
Remove size() method from parameter sources

### DIFF
--- a/eventdata/parameter_sources/elasticlogs_bulk_source.py
+++ b/eventdata/parameter_sources/elasticlogs_bulk_source.py
@@ -129,10 +129,6 @@ class ElasticlogsBulkSource:
         new_params["client_count"] = total_partitions
         return ElasticlogsBulkSource(self.orig_args[0], new_params, **self.orig_args[2])
 
-    # Deprecated - only there for BWC reasons with Rally < 1.4.0
-    def size(self):
-        return None
-
     @property
     def percent_completed(self):
         # progress is determined either by:

--- a/eventdata/parameter_sources/elasticlogs_kibana_source.py
+++ b/eventdata/parameter_sources/elasticlogs_kibana_source.py
@@ -154,10 +154,6 @@ class ElasticlogsKibanaSource:
         random.seed(seed)
         return self
 
-    # Deprecated - only there for BWC reasons with Rally < 1.4.0
-    def size(self):
-        return None
-
     def params(self):
         # Determine window_end boundaries
         if len(self._window_end) == 1:


### PR DESCRIPTION
With this commit we remove the outdated #size() method from all
parameter sources.

Closes #43