### PR TITLE
Add search_clients parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ Indexes several days of logs with a fixed (raw) logging volume per day and runni
 | Parameter               | Explanation                                                                                                                            | Type  | Default Value         |
 | ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------- | ----- | --------------------- |
 | `bulk_indexing_clients` | Number of bulk indexing clients/connections                                                                                            | `int` | `8`                   |
+| `search_clients`        | Number of search clients/connections                                                                                                   | `int` | `1`                   |
 | `bulk_size`             | Number of documents to send per bulk                                                                                                   | `int` | `1000`                |
 | `daily_logging_volume`  | The raw logging volume. Supported units are bytes (without any unit), `kb`, `MB` and `GB`). For the value, only integers are allowed.  | `str` | `100GB`               |
 | `starting_point`        | The first timestamp for which logs should be generated.                                                                                | `str` | `2018-05-25 00:00:00` |

--- a/eventdata/challenges/daily-log-volume-index-and-query.json
+++ b/eventdata/challenges/daily-log-volume-index-and-query.json
@@ -1,4 +1,5 @@
 {% set p_bulk_indexing_clients = (bulk_indexing_clients | default(8)) %}
+{% set p_search_clients = (search_clients | default(1)) %}
 {% set p_bulk_size = (bulk_size | default(1000)) %}
 {% set p_starting_point = (starting_point | default("2018-05-25 00:00:00")) %}
 {% set p_number_of_days = (number_of_days | default(6)) %}
@@ -47,7 +48,7 @@
       },
       "iterations": 1,
       {# this needs to be available for all clients, and we issue three concurrent queries #}
-      "clients": {{ p_bulk_indexing_clients + 3}}
+      "clients": {{ p_bulk_indexing_clients + (3 * p_bulk_indexing_clients) }}
     },
 {% set comma = joiner() %}
 {% for day in range(p_number_of_days) %}
@@ -93,7 +94,7 @@
               "window_end": "END",
               "window_length": "25%"
             },
-            "clients": 1,
+            "clients": {{ p_search_clients }},
             "target-interval": {{ query1_target_interval | default(90) | int }},
             "meta": {
               "querying": "yes",
@@ -116,7 +117,7 @@
               "window_end": "END",
               "window_length": "30m"
             },
-            "clients": 1,
+            "clients": {{ p_search_clients }},
             "target-interval": {{ query2_target_interval | default(30) | int }},
             "meta": {
               "querying": "yes",
@@ -140,7 +141,7 @@
               "window_end": "END",
               "window_length": "25%"
             },
-            "clients": 1,
+            "clients": {{ p_search_clients }},
             "target-interval": {{ query3_target_interval | default(45) | int }},
             "meta": {
               "querying": "yes",

--- a/eventdata/challenges/daily-log-volume-index-and-query.json
+++ b/eventdata/challenges/daily-log-volume-index-and-query.json
@@ -48,7 +48,7 @@
       },
       "iterations": 1,
       {# this needs to be available for all clients, and we issue three concurrent queries #}
-      "clients": {{ p_bulk_indexing_clients + (3 * p_bulk_indexing_clients) }}
+      "clients": {{ p_bulk_indexing_clients + (3 * p_search_clients) }}
     },
 {% set comma = joiner() %}
 {% for day in range(p_number_of_days) %}


### PR DESCRIPTION
The index-and-query-logs-fixed-daily-volume has been extended
to also be able to specify number of search clients, useful
for verifying workload patterns exhausing the available threads
in the search thread pool.