### PR TITLE
Ensure index prefix is used in index template

### DIFF
--- a/eventdata/elasticlogs-index-template.json
+++ b/eventdata/elasticlogs-index-template.json
@@ -1,3 +1,4 @@
+{% set p_index_prefix = index_prefix | default("elasticlogs") %}
 {% set p_disk_type = disk_type | default('ssd') | lower %}
 {% set p_translog_sync = translog_sync | default('request') | lower %}
 {% set p_refresh_interval = refresh_interval | default("5s") %}


### PR DESCRIPTION
With this commit we define the index prefix also in the index template
definition and not only in the track. Because the index template
definition is stored in a separate file, template variables defined in
the track are not effective and thus need to be defined separately.