### PR TITLE
Make track Rally 2.0.3-compatible

### DIFF
--- a/eventdata/parameter_sources/elasticlogs_bulk_source.py
+++ b/eventdata/parameter_sources/elasticlogs_bulk_source.py
@@ -142,7 +142,8 @@ class ElasticlogsBulkSource:
             "body": "\n".join(bulk_array),
             "action-metadata-present": True,
             # the bulk array contains the action-and-metadata line and the actual document
-            "bulk-size": len(bulk_array) // 2
+            "bulk-size": len(bulk_array) // 2,
+            "unit": "docs"
         }
 
         if "pipeline" in self._params.keys():

--- a/tests/parameter_sources/elasticlogs_bulk_source_test.py
+++ b/tests/parameter_sources/elasticlogs_bulk_source_test.py
@@ -50,6 +50,7 @@ def test_generates_a_complete_bulk():
     assert len(generated_params["body"].split("\n")) == 2 * expected_bulk_size
     assert generated_params["action-metadata-present"] is True
     assert generated_params["bulk-size"] == expected_bulk_size
+    assert generated_params["unit"] == "docs"
 
 
 def test_generates_a_bulk_that_ends_prematurely():
@@ -65,3 +66,4 @@ def test_generates_a_bulk_that_ends_prematurely():
     assert len(generated_params["body"].split("\n")) == 10
     assert generated_params["action-metadata-present"] is True
     assert generated_params["bulk-size"] == 5
+    assert generated_params["unit"] == "docs"


### PR DESCRIPTION
With this commit we add a new parameter `unit` to this track's bulk
parameter source. This parameter is mandatory for bulk parameter sources
since elastic/rally#1100.

Relates elastic/rally#1100