### PR TITLE
Add query-searchable-snapshot challenge

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,22 @@ Indexes several days of logs with a fixed (raw) logging volume per day and runni
 | `number_of_days`        | The number of simulated days for which data should be generated.                                                                       | `int` | `24`                  |
 | `number_of_shards`      | Number of primary shards                                                                                                               | `int` | `3`                   |
 
+### query-searchable-snapshot
+
+This challenge can be used to evaluate the performance of [searchable snapshots](https://www.elastic.co/guide/en/elasticsearch/reference/7.10/searchable-snapshots.html). It assumes that an appropriately sized snapshot has already been prepared. It then [mounts a snapshot](https://www.elastic.co/guide/en/elasticsearch/reference/current/searchable-snapshots-api-mount-snapshot.html) so it is searchable and runs queries against it.
+
+| Parameter                                              | Explanation                                                                                                                 | Type   | Default Value |
+|--------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------|--------|---------------|
+| `es_snapshot_repo_name`                                | The name of the snapshot repository from which the snapshot should be mounted.                                              | `str`  | -             |
+| `es_snapshot_repo_type`                                | The type of the snapshot repository from which the snapshot should be mounted.                                              | `str`  | -             |
+| `es_snapshot_repo_settings`                            | [Snapshot repository settings](https://www.elastic.co/guide/en/elasticsearch/reference/current/put-snapshot-repo-api.html). | `dict` | `{}`          |
+| `es_snapshot_name`                                     | The name of the snapshot that should be mounted. All available indices will be mounted with their original name.            | `str`  | -             |
+| `query_time_period`                                    | The period to run the parallel query tasks specified in seconds.                                                            | `int` | `1800`         |
+| `query_searchable_snapshot_content_issues_50_interval` | Time to wait in seconds between requests to the content issues dashboard covering 50% of the time range.                    | `int` | `30`           |
+| `query_searchable_snapshot_content_issues_75_interval` | Time to wait in seconds between requests to the content issues dashboard covering 75% of the time range.                    | `int` | `90`           |
+| `query_searchable_snapshot_traffic_50_interval`        | Time to wait in seconds between requests to the traffic dashboard.                                                          | `int` | `40`           |
+| `query_searchable_snapshot_discover_50_interval`       | Time to wait in seconds between requests to the discover view.                                                              | `int` | `60`           |
+
 ### bulk-update
 
 Index documents into an elasticlogs index. IDs are sequential and 40% are updates, with a uniform ID bias. The table below shows the track parameters that can be adjusted along with default values:

--- a/eventdata/challenges/query-searchable-snapshot.json
+++ b/eventdata/challenges/query-searchable-snapshot.json
@@ -1,0 +1,74 @@
+{% set p_query_time_period = (query_time_period | default(180)) %}
+{
+  "name": "query-searchable-snapshot",
+  "schedule": [
+    {
+      "name": "delete-any-old-indices",
+      "operation": {
+        "operation-type": "delete-index",
+        "index": "{{p_query_index_pattern}}"
+      }
+    },
+    {
+      "name": "register-snapshot-repository",
+      "operation": {
+        "operation-type": "create-snapshot-repository",
+        "repository": "{{ es_snapshot_repo_name }}",
+        "body": {
+          "type": "{{ es_snapshot_repo_type }}"
+{%- if es_snapshot_repo_settings is defined %}
+          ,"settings": {{ es_snapshot_repo_settings | tojson(indent=2)}}
+{%- endif%}
+        }
+      }
+    },
+    {
+      "name": "mount-searchable-snapshot",
+      "operation": {
+        "operation-type": "mount-searchable-snapshot",
+        "repository": "{{es_snapshot_repo_name}}",
+        "snapshot": "{{es_snapshot_name}}"
+      }
+    },
+    {
+      "name": "wait-for-mount",
+      "operation": {
+        "operation-type": "cluster-health",
+        "index": "{{p_query_index_pattern}}",
+        "request-params": {
+          "wait_for_status": "green"
+        }
+      }
+    },
+    {
+      "operation": "fieldstats_elasticlogs_q-*",
+      "iterations": 1,
+      "clients": 4
+    },
+    {
+      "parallel": {
+        "warmup-time-period": 0,
+        "time-period": {{ p_query_time_period }},
+        "clients": 4,
+        "tasks": [
+          {
+            "operation": "relative-kibana-content_issues-dashboard_50%",
+            "target-interval": {{ query_searchable_snapshot_content_issues_50_interval | default(30)}}
+          },
+          {
+            "operation": "relative-kibana-content_issues-dashboard_75%",
+            "target-interval": {{ query_searchable_snapshot_content_issues_75_interval | default(90)}}
+          },
+          {
+            "operation": "relative-kibana-traffic-dashboard_50%",
+            "target-interval": {{ query_searchable_snapshot_traffic_50_interval | default(40)}}
+          },
+          {
+            "operation": "relative-kibana-discover_50%",
+            "target-interval": {{ query_searchable_snapshot_discover_50_interval | default(60)}}
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/eventdata/runners/mount_searchable_snapshot_runner.py
+++ b/eventdata/runners/mount_searchable_snapshot_runner.py
@@ -1,0 +1,27 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class MountSearchableSnapshotRunner:
+    async def __call__(self, es, params):
+        repository_name = params["repository"]
+        snapshot_name = params["snapshot"]
+        snapshots = await es.snapshot.get(repository_name, snapshot_name)
+        for snapshot in snapshots["snapshots"]:
+            for index in snapshot["indices"]:
+                await es.transport.perform_request(method="POST",
+                                                   url=f"/_snapshot/{repository_name}/{snapshot_name}/_mount",
+                                                   body={"index": index})

--- a/eventdata/track.py
+++ b/eventdata/track.py
@@ -24,6 +24,7 @@ from eventdata.runners import indicesstats_runner
 from eventdata.runners import kibana_runner
 from eventdata.runners import nodestorage_runner
 from eventdata.runners import rollover_runner
+from eventdata.runners import mount_searchable_snapshot_runner
 from eventdata.schedulers import utilization_scheduler
 
 
@@ -36,6 +37,7 @@ def register(registry):
         registry.register_runner("kibana", kibana_runner.kibana_async, async_runner=True)
         registry.register_runner("node_storage", nodestorage_runner.nodestorage_async, async_runner=True)
         registry.register_runner("rollover", rollover_runner.rollover_async, async_runner=True)
+        registry.register_runner("mount-searchable-snapshot", mount_searchable_snapshot_runner.MountSearchableSnapshotRunner(), async_runner=True)
     else:
         registry.register_runner("delete_indices", deleteindex_runner.deleteindex)
         registry.register_runner("fieldstats", fieldstats_runner.fieldstats)

--- a/tests/runners/mount_searchable_snapshot_runner_test.py
+++ b/tests/runners/mount_searchable_snapshot_runner_test.py
@@ -1,0 +1,68 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from unittest import mock
+
+from eventdata.runners.mount_searchable_snapshot_runner import MountSearchableSnapshotRunner
+
+from tests import run_async, as_future
+
+
+@mock.patch("elasticsearch.Elasticsearch")
+@run_async
+async def test_mount_snapshot(es):
+    es.snapshot.get.return_value = as_future({
+        "snapshots": [
+            {
+                "snapshot": "eventdata-snapshot",
+                "uuid": "mWJnRABaSh-gdHF3-pexbw",
+                "indices": [
+                    "elasticlogs-2018-05-03",
+                    "elasticlogs-2018-05-04",
+                    "elasticlogs-2018-05-05"
+                ]
+            }
+        ]
+    })
+    # one call for each index
+    es.transport.perform_request.side_effect = [
+        as_future(),
+        as_future(),
+        as_future(),
+    ]
+
+    params = {
+        "repository": "eventdata",
+        "snapshot": "eventdata-snapshot"
+    }
+
+    runner = MountSearchableSnapshotRunner()
+
+    await runner(es, params=params)
+
+    es.snapshot.get.assert_called_once_with("eventdata", "eventdata-snapshot")
+    es.transport.perform_request.assert_has_calls([
+        mock.call(method="POST",
+                  url="/_snapshot/eventdata/eventdata-snapshot/_mount",
+                  body={"index": "elasticlogs-2018-05-03"}),
+        mock.call(method="POST",
+                  url="/_snapshot/eventdata/eventdata-snapshot/_mount",
+                  body={"index": "elasticlogs-2018-05-04"}),
+        mock.call(method="POST",
+                  url="/_snapshot/eventdata/eventdata-snapshot/_mount",
+                  body={"index": "elasticlogs-2018-05-05"}),
+    ])


### PR DESCRIPTION
With this commit we add a new challenge `query-searchable-snapshot`
which can be used to evaluate the performance of searchable snapshots.
The challenge assumes that an appropriate snapshot has already been
created.