### PR TITLE
Make searchable snapshots more compatible

### DIFF
--- a/eventdata/runners/mount_searchable_snapshot_runner.py
+++ b/eventdata/runners/mount_searchable_snapshot_runner.py
@@ -20,7 +20,14 @@ class MountSearchableSnapshotRunner:
         repository_name = params["repository"]
         snapshot_name = params["snapshot"]
         snapshots = await es.snapshot.get(repository_name, snapshot_name)
-        for snapshot in snapshots["snapshots"]:
+
+        # ES master
+        if "responses" in snapshots:
+            available_snapshots = snapshots["responses"][0]["snapshots"]
+        else:
+            available_snapshots = snapshots["snapshots"]
+
+        for snapshot in available_snapshots:
             for index in snapshot["indices"]:
                 await es.transport.perform_request(method="POST",
                                                    url=f"/_snapshot/{repository_name}/{snapshot_name}/_mount",


### PR DESCRIPTION
With this commit we allow to mount searchable snapshots with the 7.x and
the 8.x response format as the get snapshot API has changed in between
versions.

Relates #93