### PR TITLE
Wait until cluster health is green

### DIFF
--- a/eventdata/challenges/frozen.json
+++ b/eventdata/challenges/frozen.json
@@ -52,7 +52,8 @@
         "operation-type": "cluster-health",
         "request-params": {
           "wait_for_status": "green"
-        }
+        },
+        "retry-until-success": true
       }
     },
     {


### PR DESCRIPTION
With this commit we retry the cluster health check until the cluster is
green. Without this change the cluster health check might time out
before the desired status has been reached and the benchmark continues
earlier than intended.

Relates #95