### PR TITLE
Remove async backwards-compatibility layer

### DIFF
--- a/eventdata/runners/deleteindex_runner.py
+++ b/eventdata/runners/deleteindex_runner.py
@@ -19,7 +19,7 @@
 from fnmatch import fnmatch
 
 
-async def deleteindex_async(es, params):
+async def deleteindex(es, params):
     """
     Deletes all indices in Elasticsearch matching either the specified index pattern or
     the suffix of the index against a more complex pattern.
@@ -80,69 +80,5 @@ async def deleteindex_async(es, params):
             await es.indices.delete(indices_to_delete)
     else:
         await es.indices.delete(index=index_pattern)
-
-    return 1, "ops"
-
-
-def deleteindex(es, params):
-    """
-    Deletes all indices in Elasticsearch matching either the specified index pattern or
-    the suffix of the index against a more complex pattern.
-
-    :param es: Specifies the index pattern to delete. Defaults to 'elasticlogs-*'
-    :type es: str
-    :param params: Parameter hash containing one of the keys documented below.
-    :type params: dict
-
-        "index_pattern"        - Mandatory.
-                                 Specifies the index pattern to delete.
-        "max_indices"          - Optional.
-                                 int specifying how many rolled over indices to retain at max.
-                                 The elibigle indices need to satisfy `index-pattern`.
-                                 'suffix_separator' is used to retrieve the integer suffixes to calculate indices to delete.
-
-                                 Example:
-                                    For the indices: 'elasticlogs-000001', 'elasticlogs-000002', ... 000011
-                                    (index currently written to is 'elasticlogs-000011')
-
-                                    using:
-                                        suffix_separator='-' and
-                                        max_indices=8
-
-                                    will result in deleting indices 'elasticlogs-000001' and 'elasticlogs-000002'
-        "suffix_separator"     - Defaults to '-'. Used only when 'max_indices' is specified.
-                                 Specifies string separator used to extract the index suffix, e.g. '-'.
-
-
-    """
-    def get_suffix(name, separator):
-        if separator in name:
-            name_parts = name.split(separator)
-            if len(name_parts) > 1:
-                try:
-                    return int(name_parts[-1])
-                except ValueError:
-                    # TODO: log that suffix is not integer
-                    return None
-        return None
-
-    index_pattern = params['index_pattern']
-    max_indices = params.get('max_indices', None)
-    suffix_separator = params.get('suffix_separator', '-')
-
-    if max_indices:
-        indices = es.cat.indices(h='index').split("\n")
-        indices_by_suffix = {get_suffix(idx, suffix_separator): idx
-                             for idx in indices
-                             if fnmatch(idx, index_pattern) and
-                             get_suffix(idx, suffix_separator) is not None
-                             }
-
-        sorted_suffixes = sorted(list(indices_by_suffix.keys()))
-        if len(sorted_suffixes) > max_indices:
-            indices_to_delete = ",".join([indices_by_suffix[key] for key in sorted_suffixes[:(len(sorted_suffixes)-max_indices)]])
-            es.indices.delete(indices_to_delete)
-    else:
-        es.indices.delete(index=index_pattern)
 
     return 1, "ops"

--- a/eventdata/runners/fieldstats_runner.py
+++ b/eventdata/runners/fieldstats_runner.py
@@ -20,7 +20,7 @@ from eventdata.utils import globals as gs
 import logging
 
 
-async def fieldstats_async(es, params):
+async def fieldstats(es, params):
     """
     Looks up minimum and maximum values for a specified field for an index pattern and stores
     this information in a global variable that can be accessed by other components of the track.
@@ -60,69 +60,6 @@ async def fieldstats_async(es, params):
                                  }
                              },
                              params=query_params)
-
-    hits = result["hits"]["total"]
-    # ES 7.0+
-    if isinstance(hits, dict):
-        total_hits = hits["value"]
-    else:
-        total_hits = hits
-
-    if total_hits > 0:
-        key = "{}_{}".format(index_pattern, field_name)
-        min_field_value = int(result["aggregations"]["minval"]["value"])
-        max_field_value = int(result["aggregations"]["maxval"]["value"])
-        gs.global_fieldstats[key] = {
-            "max": max_field_value,
-            "min": min_field_value
-        }
-        logger = logging.getLogger("track.eventdata.fieldstats")
-        logger.info("Identified statistics for field '%s' in '%s'. Min: %d, Max: %d",
-                    field_name, index_pattern, min_field_value, max_field_value)
-    else:
-        raise AssertionError("No matching data found for field '{}' in pattern '{}'.".format(field_name, index_pattern))
-
-
-def fieldstats(es, params):
-    """
-    Looks up minimum and maximum values for a specified field for an index pattern and stores
-    this information in a global variable that can be accessed by other components of the track.
-
-    It expects a parameter dictionary with the following keys:
-
-    * index_pattern (mandatory): Index pattern statistics are retrieved for.
-    * fieldname (optional): Field to extract statistics for. Defaults to "@timestamp".
-
-    """
-    index_pattern = params["index_pattern"]
-    field_name = params.get("fieldname", "@timestamp")
-    ignore_throttled = params.get("ignore_throttled", True)
-
-    if ignore_throttled:
-        query_params = {}
-    else:
-        query_params = {"ignore_throttled": "false"}
-
-    result = es.search(index=index_pattern,
-                       body={
-                           "query": {
-                               "match_all": {}
-                           },
-                           "size": 0,
-                           "aggs": {
-                               "maxval": {
-                                   "max": {
-                                       "field": field_name
-                                   }
-                               },
-                               "minval": {
-                                   "min": {
-                                       "field": field_name
-                                   }
-                               }
-                           }
-                       },
-                       params=query_params)
 
     hits = result["hits"]["total"]
     # ES 7.0+

--- a/eventdata/runners/indicesstats_runner.py
+++ b/eventdata/runners/indicesstats_runner.py
@@ -24,7 +24,7 @@ import logging
 logger = logging.getLogger("track.eventdata")
 
 
-async def indicesstats_async(es, params):
+async def indicesstats(es, params):
     """
     Retrieves index stats for an index or index pattern.
 
@@ -40,64 +40,6 @@ async def indicesstats_async(es, params):
 
     try:
         result = await es.indices.stats(index=index_pattern, metric='store,docs,segments')
-
-        if result['_all']:
-            a = result['_all']
-
-            if a['primaries']['docs']['count']:
-                response['primary_doc_count'] = a['primaries']['docs']['count']
-
-            if a['total']['docs']['count']:
-                response['total_doc_count'] = a['total']['docs']['count']
-
-            if a['primaries']['store']['size_in_bytes']:
-                response['primary_size_bytes'] = a['primaries']['store']['size_in_bytes']
-
-            if a['total']['store']['size_in_bytes']:
-                response['total_size_bytes'] = a['total']['store']['size_in_bytes']
-
-            if a['primaries']['segments']['count']:
-                response['primary_segment_count'] = a['primaries']['segments']['count']
-
-            if a['total']['segments']['count']:
-                response['total_segment_count'] = a['total']['segments']['count']
-
-            if a['primaries']['segments']['memory_in_bytes']:
-                response['primary_segments_memory_in_bytes'] = a['primaries']['segments']['memory_in_bytes']
-
-            if a['total']['segments']['memory_in_bytes']:
-                response['total_segment_memory_in_bytes'] = a['total']['segments']['memory_in_bytes']
-
-            if a['primaries']['segments']['terms_memory_in_bytes']:
-                response['primary_segment_terms_memory_in_bytes'] = a['primaries']['segments']['terms_memory_in_bytes']
-
-            if a['total']['segments']['terms_memory_in_bytes']:
-                response['total_segment_terms_memory_in_bytes'] = a['total']['segments']['terms_memory_in_bytes']
-
-        if logger.isEnabledFor(logging.DEBUG):
-            logger.debug("Indices stats for {} => {}".format(index_pattern, json.dumps(result)))
-    except elasticsearch.TransportError as e:
-        logger.info("[indicesstats_runner] Error: {}".format(e))
-
-    return response
-
-
-def indicesstats(es, params):
-    """
-    Retrieves index stats for an index or index pattern.
-
-    It expects the parameter hash to contain the following keys:
-        "index_pattern" - Index pattern that storage statistics are retrieved for.
-    """
-    index_pattern = params['index_pattern']
-    response = {
-        "weight": 1,
-        "unit": "ops",
-        "index_pattern": index_pattern
-    }
-
-    try:
-        result = es.indices.stats(index=index_pattern, metric='store,docs,segments')
 
         if result['_all']:
             a = result['_all']

--- a/eventdata/runners/nodestorage_runner.py
+++ b/eventdata/runners/nodestorage_runner.py
@@ -25,7 +25,7 @@ logger = logging.getLogger("track.eventdata")
 BYTES_PER_TB = 1024 * 1024 * 1024 * 1024
 
 
-async def nodestorage_async(es, params):
+async def nodestorage(es, params):
     """
     Calculates the total data volume in the cluster as well as average volume per data node.
 
@@ -48,50 +48,6 @@ async def nodestorage_async(es, params):
                 data_node_count += 1
 
         result = await es.indices.stats(index='*', metric='store')
-        total_data_size = 0
-
-        if result['_all']:
-            if result['_all']['total']['store']['size_in_bytes']:
-                total_data_size = result['_all']['total']['store']['size_in_bytes']
-
-        total_data_size_tb = float(total_data_size) / BYTES_PER_TB
-
-        volume_per_data_node = int(total_data_size / data_node_count)
-        volume_per_data_node_tb = total_data_size_tb / data_node_count
-
-        response['total_data_volume_bytes'] = total_data_size
-        response['total_data_volume_tb'] = total_data_size_tb
-        response['average_data_volume_per_node_bytes'] = volume_per_data_node
-        response['average_data_volume_per_node_tb'] = volume_per_data_node_tb
-
-    except elasticsearch.TransportError as e:
-        logger.info("[nodestorage_runner] Error: {}".format(e))
-
-    return response
-
-
-def nodestorage(es, params):
-    """
-    Calculates the total data volume in the cluster as well as average volume per data node.
-
-    It takes no parameters.
-    """
-    response = {
-        "weight": 1,
-        "unit": "ops"
-    }
-
-    try:
-        # get number of data nodes
-        node_role_list = es.cat.nodes(h="node.role")
-
-        data_node_count = 0
-
-        for node_role in node_role_list:
-            if 'd' in node_role:
-                data_node_count += 1
-
-        result = es.indices.stats(index='*', metric='store')
         total_data_size = 0
 
         if result['_all']:

--- a/eventdata/runners/rollover_runner.py
+++ b/eventdata/runners/rollover_runner.py
@@ -16,7 +16,7 @@
 # under the License.
 
 
-async def rollover_async(es, params):
+async def rollover(es, params):
     """
     Runs a rollover operation against Elasticsearch.
 
@@ -25,16 +25,4 @@ async def rollover_async(es, params):
 
     """
     await es.indices.rollover(alias=params["alias"], body=params["body"])
-    return 1, "ops"
-
-
-def rollover(es, params):
-    """
-    Runs a rollover operation against Elasticsearch.
-
-    It expects the parameter hash to contain a key "alias" specifying the alias to rollover 
-    as well as a key "body" containing the actual rollover request and associated conditions.
-
-    """
-    es.indices.rollover(alias=params["alias"], body=params["body"])
     return 1, "ops"

--- a/eventdata/track.py
+++ b/eventdata/track.py
@@ -29,22 +29,13 @@ from eventdata.schedulers import utilization_scheduler
 
 
 def register(registry):
-    async_runner = registry.meta_data.get("async_runner", False)
-    if async_runner:
-        registry.register_runner("delete_indices", deleteindex_runner.deleteindex_async, async_runner=True)
-        registry.register_runner("fieldstats", fieldstats_runner.fieldstats_async, async_runner=True)
-        registry.register_runner("indicesstats", indicesstats_runner.indicesstats_async, async_runner=True)
-        registry.register_runner("kibana", kibana_runner.kibana_async, async_runner=True)
-        registry.register_runner("node_storage", nodestorage_runner.nodestorage_async, async_runner=True)
-        registry.register_runner("rollover", rollover_runner.rollover_async, async_runner=True)
-        registry.register_runner("mount-searchable-snapshot", mount_searchable_snapshot_runner.MountSearchableSnapshotRunner(), async_runner=True)
-    else:
-        registry.register_runner("delete_indices", deleteindex_runner.deleteindex)
-        registry.register_runner("fieldstats", fieldstats_runner.fieldstats)
-        registry.register_runner("indicesstats", indicesstats_runner.indicesstats)
-        registry.register_runner("kibana", kibana_runner.kibana)
-        registry.register_runner("node_storage", nodestorage_runner.nodestorage)
-        registry.register_runner("rollover", rollover_runner.rollover)
+    registry.register_runner("delete_indices", deleteindex_runner.deleteindex, async_runner=True)
+    registry.register_runner("fieldstats", fieldstats_runner.fieldstats, async_runner=True)
+    registry.register_runner("indicesstats", indicesstats_runner.indicesstats, async_runner=True)
+    registry.register_runner("kibana", kibana_runner.kibana, async_runner=True)
+    registry.register_runner("node_storage", nodestorage_runner.nodestorage, async_runner=True)
+    registry.register_runner("rollover", rollover_runner.rollover, async_runner=True)
+    registry.register_runner("mount-searchable-snapshot", mount_searchable_snapshot_runner.MountSearchableSnapshotRunner(), async_runner=True)
 
     registry.register_param_source("elasticlogs_bulk", ElasticlogsBulkSource)
     registry.register_param_source("elasticlogs_kibana", ElasticlogsKibanaSource)

--- a/tests/runners/kibana_runner_test.py
+++ b/tests/runners/kibana_runner_test.py
@@ -17,7 +17,7 @@
 
 from unittest import mock
 
-from eventdata.runners.kibana_runner import kibana_async
+from eventdata.runners.kibana_runner import kibana
 
 from tests import run_async, as_future
 
@@ -59,7 +59,7 @@ async def test_msearch_without_hits(es):
         ]
     })
 
-    response = await kibana_async(es, params=params)
+    response = await kibana(es, params=params)
 
     assert response == {
         "debug": True,
@@ -141,7 +141,7 @@ async def test_msearch_with_hits_as_number(es):
         ]
     })
 
-    response = await kibana_async(es, params=params)
+    response = await kibana(es, params=params)
 
     assert response == {
         "debug": True,
@@ -230,7 +230,7 @@ async def test_msearch_with_hits_as_dict(es):
         ]
     })
 
-    response = await kibana_async(es, params=params)
+    response = await kibana(es, params=params)
 
     assert response == {
         "debug": True,
@@ -292,7 +292,7 @@ async def test_msearch_with_error(es):
         ]
     })
 
-    response = await kibana_async(es, params=params)
+    response = await kibana(es, params=params)
 
     assert response == {
         "debug": True,


### PR DESCRIPTION
With this commit we remove all runners that use the blocking
Elasticsearch client API methods. This means that this track requires at
least Rally 2.0.0 (released on May 7, 2020).

Closes #81