### PR TITLE
Commit fixed indexing load and parallel query challenge

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,11 +55,11 @@ check-venv:
 	fi
 
 install: venv-create
-	. $(VENV_ACTIVATE_FILE); pip install --upgrade pip
+	. $(VENV_ACTIVATE_FILE); python3 -mpip install --upgrade pip
 	# install pytest for tests
-	. $(VENV_ACTIVATE_FILE); pip3 install pytest==5.1.1
+	. $(VENV_ACTIVATE_FILE); python3 -mpip install pytest==5.1.1
 	# install (latest) Rally for smoke tests
-	. $(VENV_ACTIVATE_FILE); pip3 install git+ssh://git@github.com/elastic/rally.git
+	. $(VENV_ACTIVATE_FILE); python3 -mpip install git+ssh://git@github.com/elastic/rally.git
 
 clean:
 	rm -rf .pytest_cache

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ Note: In general, track parameters are only defined for a subset of the challeng
 
 | Parameter | Explanation | Type | Default Value |
 | --------- | ----------- | ---- | ------------- |
+| `index_prefix` | The prefix for generated indices. | `str` |  `elasticlogs` |
+| `number_of_shards` | The number primary shards generated indices will have. | `int` | 2 |
+| `number_of_replicas` | The number replicas generated indices will have. | `int` | 0 |
 | `record_raw_event_size` | Adds a new field `_raw_event_size` to the index which contains the size of the raw logging event in bytes. | `bool` | `False` |
 | `query_index_prefix` | Start of the index name(s) used in queries for this track. | `str` | `elasticlogs_q` |
 | `query_index_pattern` | Index pattern used in queries for this track. | `str` | `$query_index_prefix + "-*"` |
@@ -165,7 +168,7 @@ This challenge indexes a fixed (raw) logging volume of logs per day into daily i
 
 ### index-and-query-logs-fixed-daily-volume
 
-Indexes several days of logs with a fixed (raw) logging volume per day and running queries concurrently. This challenge will complete tasks as quickly as possible and won't take the amount of days specified in the number_of_days field. The table below shows the track parameters that can be adjusted along with default values:
+Indexes several days of logs with a fixed (raw) logging volume per day and running queries concurrently. Requires executing `index-logs-fixed-daily-volume` first. This challenge will complete tasks as quickly as possible and won't take into account the amount of days specified in the number_of_days field. The table below shows the track parameters that can be adjusted along with default values:
 
 | Parameter               | Explanation                                                                                                                            | Type  | Default Value         |
 | ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------- | ----- | --------------------- |
@@ -174,8 +177,22 @@ Indexes several days of logs with a fixed (raw) logging volume per day and runni
 | `bulk_size`             | Number of documents to send per bulk                                                                                                   | `int` | `1000`                |
 | `daily_logging_volume`  | The raw logging volume. Supported units are bytes (without any unit), `kb`, `MB` and `GB`). For the value, only integers are allowed.  | `str` | `100GB`               |
 | `starting_point`        | The first timestamp for which logs should be generated.                                                                                | `str` | `2018-05-25 00:00:00` |
-| `number_of_days`        | The number of simulated days for which data should be generated.                                                                       | `int` | `24`                  |
-| `number_of_shards`      | Number of primary shards                                                                                                               | `int` | `3`                   |
+| `number_of_days`        | The number of simulated days for which data should be generated.                                                                       | `int` | `6`                  |
+
+### index-fixed-load-and-query
+
+Indexes (several days of) logs at a fixed target throughput using a fixed (raw) logging volume per day while running queries concurrently.  Requires executing `index-logs-fixed-daily-volume` first. This challenge will end as soon the indexing task has completed. The table below shows the track parameters that can be adjusted along with default values:
+
+| Parameter                    | Explanation                                                                                                                            | Type  | Default Value         |
+| ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- | ----- | --------------------- |
+| `bulk_indexing_reqs_per_sec` | Number of bulk indexing requests/sec. Multiply this by bulk_size to understand indexing throughput in docs/s.                          | `int` | `20`                  |                                                    
+| `bulk_size`                  | Number of documents to send per bulk                                                                                                   | `int` | `1000`                |
+| `bulk_indexing_clients`      | Number of bulk indexing clients/connections                                                                                            | `int` | `8`                   |
+| `search_clients`             | Number of search clients/connections                                                                                                   | `int` | `1`                   |
+| `daily_logging_volume`       | The raw logging volume. Supported units are bytes (without any unit), `kb`, `MB` and `GB`). For the value, only integers are allowed.  | `str` | `100GB`               |
+| `starting_point`             | The first timestamp for which logs should be generated.                                                                                | `str` | `2018-05-25 00:00:00` |
+| `number_of_days`             | The number of simulated days for which data should be generated.                                                                       | `int` | `6`                  |
+
 
 ### query-searchable-snapshot
 

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ This challenge indexes a fixed (raw) logging volume of logs per day into daily i
 | ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------- | ----- | --------------------- |
 | `bulk_indexing_clients` | Number of bulk indexing clients/connections                                                                                            | `int` | `8`                   |
 | `bulk_size`             | Number of documents to send per bulk                                                                                                   | `int` | `1000`                |
-| `daily_logging_volume`  | The raw logging volume. Supported units are bytes (without any unit), `kb`, `MB` and `GB`). For the value, only integers are allowed.  | `str` | `100GB`               |
+| `daily_logging_volume`  | The raw logging volume. Supported units are bytes (without any unit), `KB`, `MB` and `GB`). For the value, only integers are allowed.  | `str` | `100GB`               |
 | `starting_point`        | The first timestamp for which logs should be generated.                                                                                | `str` | `2018-05-01:00:00:00` |
 | `number_of_days`        | The number of simulated days for which data should be generated.                                                                       | `int` | `24`                  |
 | `number_of_shards`      | Number of primary shards                                                                                                               | `int` | `3`                   |
@@ -173,11 +173,11 @@ Indexes several days of logs with a fixed (raw) logging volume per day and runni
 | Parameter               | Explanation                                                                                                                            | Type  | Default Value         |
 | ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------- | ----- | --------------------- |
 | `bulk_indexing_clients` | Number of bulk indexing clients/connections                                                                                            | `int` | `8`                   |
-| `search_clients`        | Number of search clients/connections                                                                                                   | `int` | `1`                   |
+| `search_clients`        | Number of search clients/connections used by *each** query                                                                             | `int` | `1`                   |
 | `bulk_size`             | Number of documents to send per bulk                                                                                                   | `int` | `1000`                |
-| `daily_logging_volume`  | The raw logging volume. Supported units are bytes (without any unit), `kb`, `MB` and `GB`). For the value, only integers are allowed.  | `str` | `100GB`               |
+| `daily_logging_volume`  | The raw logging volume. Supported units are bytes (without any unit), `KB`, `MB` and `GB`). For the value, only integers are allowed.  | `str` | `100GB`               |
 | `starting_point`        | The first timestamp for which logs should be generated.                                                                                | `str` | `2018-05-25 00:00:00` |
-| `number_of_days`        | The number of simulated days for which data should be generated.                                                                       | `int` | `6`                  |
+| `number_of_days`        | The number of simulated days for which data should be generated.                                                                       | `int` | `6`                   |
 
 ### index-fixed-load-and-query
 
@@ -188,10 +188,10 @@ Indexes (several days of) logs at a fixed target throughput using a fixed (raw) 
 | `bulk_indexing_reqs_per_sec` | Number of bulk indexing requests/sec. Multiply this by bulk_size to understand indexing throughput in docs/s.                          | `int` | `20`                  |                                                    
 | `bulk_size`                  | Number of documents to send per bulk                                                                                                   | `int` | `1000`                |
 | `bulk_indexing_clients`      | Number of bulk indexing clients/connections                                                                                            | `int` | `8`                   |
-| `search_clients`             | Number of search clients/connections                                                                                                   | `int` | `1`                   |
-| `daily_logging_volume`       | The raw logging volume. Supported units are bytes (without any unit), `kb`, `MB` and `GB`). For the value, only integers are allowed.  | `str` | `100GB`               |
+| `search_clients`             | Number of search clients/connections used by *each** query                                                                             | `int` | `1`                   |
+| `daily_logging_volume`       | The raw logging volume. Supported units are bytes (without any unit), `KB`, `MB` and `GB`). For the value, only integers are allowed.  | `str` | `100GB`               |
 | `starting_point`             | The first timestamp for which logs should be generated.                                                                                | `str` | `2018-05-25 00:00:00` |
-| `number_of_days`             | The number of simulated days for which data should be generated.                                                                       | `int` | `6`                  |
+| `number_of_days`             | The number of simulated days for which data should be generated.                                                                       | `int` | `6`                   |
 
 
 ### query-searchable-snapshot

--- a/eventdata/challenges/daily-log-index-fixed-throughput-and-query.json
+++ b/eventdata/challenges/daily-log-index-fixed-throughput-and-query.json
@@ -15,7 +15,7 @@
   "name": "index-fixed-load-and-query",
   "description": "Indexes {{ p_number_of_days }} days of logs (each {{ p_daily_logging_volume }} size) running at {{ p_bulk_indexing_throughput }} docs/s while running queries concurrently",
   "meta": {
-    "client_count": {{ p_bulk_indexing_clients }},
+    "bulk_client_count": {{ p_bulk_indexing_clients }},
     "benchmark_type": "logs-fixed-index-daily-throughput-and-query"
   },
   "schedule": [
@@ -25,9 +25,10 @@
         "operation-type": "cluster-health",
         "index": "{{ p_index_prefix }}-*",
         "request-params": {
-        "wait_for_status": "{{cluster_health | default('green')}}",
-        "wait_for_no_relocating_shards": "true"
-        }
+          "wait_for_status": "{{cluster_health | default('green')}}",
+          "wait_for_no_relocating_shards": "true"
+        },
+        "retry-until-success": true
       }
     },
     {

--- a/eventdata/challenges/daily-log-index-fixed-throughput-and-query.json
+++ b/eventdata/challenges/daily-log-index-fixed-throughput-and-query.json
@@ -1,6 +1,8 @@
 {% set p_bulk_indexing_clients = (bulk_indexing_clients | default(8)) %}
-{% set p_search_clients = (search_clients | default(1)) %}
 {% set p_bulk_size = (bulk_size | default(1000)) %}
+{% set p_bulk_indexing_reqs_per_sec = (bulk_indexing_reqs_per_sec | default(20)) %}
+{% set p_bulk_indexing_throughput = (p_bulk_indexing_reqs_per_sec * p_bulk_size) %}
+{% set p_search_clients = (search_clients | default(1)) %}
 {% set p_starting_point = (starting_point | default("2018-05-25 00:00:00")) %}
 {% set p_number_of_days = (number_of_days | default(6)) %}
 {% set p_daily_logging_volume = (daily_logging_volume | default("100GB")) %}
@@ -10,45 +12,21 @@
 #}
 
 {
-  "name": "index-and-query-logs-fixed-daily-volume",
-  "description": "Indexes {{p_number_of_days}} days of logs with a fixed (raw) logging volume of {{p_daily_logging_volume}} per day and running queries concurrently",
+  "name": "index-fixed-load-and-query",
+  "description": "Indexes {{ p_number_of_days }} days of logs (each {{ p_daily_logging_volume }} size) running at {{ p_bulk_indexing_throughput }} docs/s while running queries concurrently",
   "meta": {
     "client_count": {{ p_bulk_indexing_clients }},
-    "benchmark_type": "logs-fixed-daily-volume"
+    "benchmark_type": "logs-fixed-index-daily-throughput-and-query"
   },
   "schedule": [
-    {
-      "name": "measure-maximum-utilization",
-       "operation": {
-          "operation-type": "bulk",
-          "param-source": "elasticlogs_bulk",
-          "index": "elasticlogs-2999-01-01-throughput-test",
-          "bulk-size": {{p_bulk_size}},
-          "daily_logging_volume": "{{p_daily_logging_volume}}",
-          "number_of_days": 1,
-          "record_raw_event_size": false
-       },
-      {# Whatever is shorter will win - either we run for this long or we finished ingesting the daily logging volume #}
-      "time-period": 600,
-      "schedule": "utilization",
-      "record-response-times": true,
-      "clients": {{ p_bulk_indexing_clients }}
-    },
-    {
-      "name": "delete-measurement-index",
-      "operation": {
-        "operation-type": "delete-index",
-        "index": "elasticlogs-2999-01-01-throughput-test"
-      }
-    },
     {
       "name": "check-cluster-health",
       "operation": {
         "operation-type": "cluster-health",
         "index": "{{ index_prefix }}-*",
         "request-params": {
-          "wait_for_status": "{{cluster_health | default('green')}}",
-          "wait_for_no_relocating_shards": "true"
+        "wait_for_status": "{{cluster_health | default('green')}}",
+        "wait_for_no_relocating_shards": "true"
         }
       }
     },
@@ -61,44 +39,36 @@
       {# this needs to be available for all clients, and we issue three concurrent queries #}
       "clients": {{ p_bulk_indexing_clients + (3 * p_search_clients) }}
     },
-{% set comma = joiner() %}
-{% for day in range(p_number_of_days) %}
-{% set utilization = (day + 1) / p_number_of_days %}
-{% set utilization_task_suffix = ((utilization * 100) | round | int) ~ "%-utilization" %}
-{% set bulk_index_task_name = "bulk-index-logs-" + utilization_task_suffix %}
-{{comma()}}
     {
       "parallel": {
-        "completed-by": "{{bulk_index_task_name}}",
+        "completed-by": "index-fixed-throughput",
         {# We are assuming that indexing one day of logs takes longer than the warmup-time-period #}
         "warmup-time-period": 600,
         "tasks": [
           {
             "operation": {
-              "name": "{{bulk_index_task_name}}",
+              "name": "index-fixed-throughput",
               "operation-type": "bulk",
               "param-source": "elasticlogs_bulk",
               "index": "{{ index_prefix }}-<yyyy>-<mm>-<dd>",
-              "starting_point": "{{p_starting_point}}",
-              "offset": "+{{day}}d",
-              "bulk-size": {{p_bulk_size}},
-              "daily_logging_volume": "{{p_daily_logging_volume}}",
-              "number_of_days": 1,
-              "record_raw_event_size": {{p_record_raw_event_size}}
+              "starting_point": "{{ p_starting_point }}",
+              "bulk-size": {{ p_bulk_size }},
+              "daily_logging_volume": "{{ p_daily_logging_volume }}",
+              "number_of_days": {{ p_number_of_days }}
             },
-            "schedule": "utilization",
-            "target-utilization": {{ utilization }},
+            "target-throughput": {{ p_bulk_indexing_reqs_per_sec }},
             "clients": {{ p_bulk_indexing_clients }},
             "meta": {
-              "utilization": {{ utilization }}
+              "target_indexing_throughput": "{{ p_bulk_indexing_reqs_per_sec * p_bulk_size }}",
+              "target_indexing_throughput_unit": "docs/s"
             }
           },
           {
-            "name": "traffic-dashboard-25%-{{utilization_task_suffix}}",
+            "name": "traffic-dashboard-25%",
             "operation": {
               "operation-type": "kibana",
               "param-source": "elasticlogs_kibana",
-              "debug": {{p_verbose}},
+              "debug": {{ p_verbose }},
               "dashboard": "traffic",
               "index_pattern": "{{ index_prefix }}-*",
               "query_string": "query_string_lists/country_code_query_strings.json",
@@ -110,20 +80,19 @@
             "meta": {
               "querying": "yes",
               "query_type": "relative",
-              "utilization": {{ utilization }},
               "dashboard": "traffic",
               "window_length": "25%"
             },
             "schedule": "poisson"
           },
           {
-            "name": "discover-30m-{{utilization_task_suffix}}",
+            "name": "discover-30m",
             "operation": {
               "operation-type": "kibana",
               "param-source": "elasticlogs_kibana",
-              "debug": {{p_verbose}},
+              "debug": {{ p_verbose }},
               "dashboard": "discover",
-              "index_pattern": "elasticlogs-*",
+              "index_pattern": "{{ index_prefix }}-*",
               "query_string": ["*"],
               "window_end": "END",
               "window_length": "30m"
@@ -133,19 +102,18 @@
             "meta": {
               "querying": "yes",
               "query_type": "relative",
-              "utilization": {{ utilization }},
               "dashboard": "discover",
               "window_length": "30m"
             },
             "schedule": "poisson"
           },
           {
-            "name": "content_issues-dashboard-25%-{{utilization_task_suffix}}",
+            "name": "content_issues-dashboard-25%",
             "#COMMENT": "Looks only for 404s about 1-1.5% of data",
             "operation": {
               "operation-type": "kibana",
               "param-source": "elasticlogs_kibana",
-              "debug": {{p_verbose}},
+              "debug": {{ p_verbose }},
               "dashboard": "content_issues",
               "index_pattern": "{{ index_prefix }}-*",
               "query_string": ["*"],
@@ -157,7 +125,6 @@
             "meta": {
               "querying": "yes",
               "query_type": "relative",
-              "utilization": {{ utilization }},
               "dashboard": "content_issues",
               "window_length": "25%"
             },
@@ -166,6 +133,5 @@
         ]
       }
     }
-{% endfor%}
   ]
 }

--- a/eventdata/challenges/daily-log-index-fixed-throughput-and-query.json
+++ b/eventdata/challenges/daily-log-index-fixed-throughput-and-query.json
@@ -23,7 +23,7 @@
       "name": "check-cluster-health",
       "operation": {
         "operation-type": "cluster-health",
-        "index": "{{ index_prefix }}-*",
+        "index": "{{ p_index_prefix }}-*",
         "request-params": {
         "wait_for_status": "{{cluster_health | default('green')}}",
         "wait_for_no_relocating_shards": "true"
@@ -33,7 +33,7 @@
     {
       "operation": {
         "operation-type": "fieldstats",
-        "index_pattern": "{{ index_prefix }}-*"
+        "index_pattern": "{{ p_index_prefix }}-*"
       },
       "iterations": 1,
       {# this needs to be available for all clients, and we issue three concurrent queries #}
@@ -50,7 +50,7 @@
               "name": "index-fixed-throughput",
               "operation-type": "bulk",
               "param-source": "elasticlogs_bulk",
-              "index": "{{ index_prefix }}-<yyyy>-<mm>-<dd>",
+              "index": "{{ p_index_prefix }}-<yyyy>-<mm>-<dd>",
               "starting_point": "{{ p_starting_point }}",
               "bulk-size": {{ p_bulk_size }},
               "daily_logging_volume": "{{ p_daily_logging_volume }}",
@@ -70,7 +70,7 @@
               "param-source": "elasticlogs_kibana",
               "debug": {{ p_verbose }},
               "dashboard": "traffic",
-              "index_pattern": "{{ index_prefix }}-*",
+              "index_pattern": "{{ p_index_prefix }}-*",
               "query_string": "query_string_lists/country_code_query_strings.json",
               "window_end": "END",
               "window_length": "25%"
@@ -92,7 +92,7 @@
               "param-source": "elasticlogs_kibana",
               "debug": {{ p_verbose }},
               "dashboard": "discover",
-              "index_pattern": "{{ index_prefix }}-*",
+              "index_pattern": "{{ p_index_prefix }}-*",
               "query_string": ["*"],
               "window_end": "END",
               "window_length": "30m"
@@ -115,7 +115,7 @@
               "param-source": "elasticlogs_kibana",
               "debug": {{ p_verbose }},
               "dashboard": "content_issues",
-              "index_pattern": "{{ index_prefix }}-*",
+              "index_pattern": "{{ p_index_prefix }}-*",
               "query_string": ["*"],
               "window_end": "END",
               "window_length": "25%"

--- a/eventdata/challenges/daily-log-volume-index-and-query.json
+++ b/eventdata/challenges/daily-log-volume-index-and-query.json
@@ -45,7 +45,7 @@
       "name": "check-cluster-health",
       "operation": {
         "operation-type": "cluster-health",
-        "index": "{{ index_prefix }}-*",
+        "index": "{{ p_index_prefix }}-*",
         "request-params": {
           "wait_for_status": "{{cluster_health | default('green')}}",
           "wait_for_no_relocating_shards": "true"
@@ -55,7 +55,7 @@
     {
       "operation": {
         "operation-type": "fieldstats",
-        "index_pattern": "{{ index_prefix }}-*"
+        "index_pattern": "{{ p_index_prefix }}-*"
       },
       "iterations": 1,
       {# this needs to be available for all clients, and we issue three concurrent queries #}
@@ -78,7 +78,7 @@
               "name": "{{bulk_index_task_name}}",
               "operation-type": "bulk",
               "param-source": "elasticlogs_bulk",
-              "index": "{{ index_prefix }}-<yyyy>-<mm>-<dd>",
+              "index": "{{ p_index_prefix }}-<yyyy>-<mm>-<dd>",
               "starting_point": "{{p_starting_point}}",
               "offset": "+{{day}}d",
               "bulk-size": {{p_bulk_size}},
@@ -100,7 +100,7 @@
               "param-source": "elasticlogs_kibana",
               "debug": {{p_verbose}},
               "dashboard": "traffic",
-              "index_pattern": "{{ index_prefix }}-*",
+              "index_pattern": "{{ p_index_prefix }}-*",
               "query_string": "query_string_lists/country_code_query_strings.json",
               "window_end": "END",
               "window_length": "25%"
@@ -147,7 +147,7 @@
               "param-source": "elasticlogs_kibana",
               "debug": {{p_verbose}},
               "dashboard": "content_issues",
-              "index_pattern": "{{ index_prefix }}-*",
+              "index_pattern": "{{ p_index_prefix }}-*",
               "query_string": ["*"],
               "window_end": "END",
               "window_length": "25%"

--- a/eventdata/challenges/daily-log-volume-index-and-query.json
+++ b/eventdata/challenges/daily-log-volume-index-and-query.json
@@ -49,7 +49,8 @@
         "request-params": {
           "wait_for_status": "{{cluster_health | default('green')}}",
           "wait_for_no_relocating_shards": "true"
-        }
+        },
+        "retry-until-success": true
       }
     },
     {

--- a/eventdata/challenges/daily-log-volume-index.json
+++ b/eventdata/challenges/daily-log-volume-index.json
@@ -38,7 +38,8 @@
         "request-params": {
           "wait_for_status": "{{cluster_health | default('green')}}",
           "wait_for_no_relocating_shards": "true"
-        }
+        },
+        "retry-until-success": true
       }
     },
     {

--- a/eventdata/challenges/daily-log-volume-index.json
+++ b/eventdata/challenges/daily-log-volume-index.json
@@ -13,10 +13,10 @@
   },
   "schedule": [
     {
-      "name": "delete-index-{{ index_prefix }}-*",
+      "name": "delete-index-{{ p_index_prefix }}-*",
       "operation": {
         "operation-type": "delete-index",
-        "index": "{{ index_prefix }}-*"
+        "index": "{{ p_index_prefix }}-*"
       }
     },
     {
@@ -34,7 +34,7 @@
       "name": "check-cluster-health",
       "operation": {
         "operation-type": "cluster-health",
-        "index": "{{ index_prefix }}-*",
+        "index": "{{ p_index_prefix }}-*",
         "request-params": {
           "wait_for_status": "{{cluster_health | default('green')}}",
           "wait_for_no_relocating_shards": "true"
@@ -46,7 +46,7 @@
       "operation": {
         "operation-type": "bulk",
         "param-source": "elasticlogs_bulk",
-        "index": "{{ index_prefix }}-<yyyy>-<mm>-<dd>",
+        "index": "{{ p_index_prefix }}-<yyyy>-<mm>-<dd>",
         "starting_point": "{{p_starting_point}}",
         "bulk-size": {{p_bulk_size}},
         "daily_logging_volume": "{{p_daily_logging_volume}}",

--- a/eventdata/challenges/daily-log-volume-index.json
+++ b/eventdata/challenges/daily-log-volume-index.json
@@ -13,10 +13,10 @@
   },
   "schedule": [
     {
-      "name": "delete-index-elasticlogs-*",
+      "name": "delete-index-{{ index_prefix }}-*",
       "operation": {
         "operation-type": "delete-index",
-        "index": "elasticlogs-*"
+        "index": "{{ index_prefix }}-*"
       }
     },
     {
@@ -31,11 +31,22 @@
       }
     },
     {
+      "name": "check-cluster-health",
+      "operation": {
+        "operation-type": "cluster-health",
+        "index": "{{ index_prefix }}-*",
+        "request-params": {
+          "wait_for_status": "{{cluster_health | default('green')}}",
+          "wait_for_no_relocating_shards": "true"
+        }
+      }
+    },
+    {
       "name": "bulk-index-logs",
       "operation": {
         "operation-type": "bulk",
         "param-source": "elasticlogs_bulk",
-        "index": "elasticlogs-<yyyy>-<mm>-<dd>",
+        "index": "{{ index_prefix }}-<yyyy>-<mm>-<dd>",
         "starting_point": "{{p_starting_point}}",
         "bulk-size": {{p_bulk_size}},
         "daily_logging_volume": "{{p_daily_logging_volume}}",

--- a/smoke-test.sh
+++ b/smoke-test.sh
@@ -32,7 +32,7 @@ readonly ES_VERSION=${ES_VERSION:-7.3.0}
 # * frozen-querying (depends on frozen-data-generation)
 # * combined-indexing-and-querying (depends on any challenge that has already created elasticlogs-q* indices)
 # * elasticlogs-querying (depends on any challenge that has already created elasticlogs-q* indices)
-readonly CHALLENGES=(frozen-data-generation frozen-querying elasticlogs-continuous-index-and-query bulk-update index-logs-fixed-daily-volume index-and-query-logs-fixed-daily-volume elasticlogs-1bn-load combined-indexing-and-querying elasticlogs-querying)
+readonly CHALLENGES=(frozen-data-generation frozen-querying elasticlogs-continuous-index-and-query bulk-update index-logs-fixed-daily-volume index-and-query-logs-fixed-daily-volume index-fixed-load-and-query elasticlogs-1bn-load combined-indexing-and-querying elasticlogs-querying)
 
 INSTALL_ID=-1
 


### PR DESCRIPTION
Add a challenge that runs three parallel queries while running in
parallel an indexing task with fixed throughput (supplied via a track
param).

Also fix track parameter bugs in README and allow specifying the
index_prefix in the challenges `index-and-query-logs-fixed-daily-volume`
and `index-logs-fixed-daily-volume`.