### PR TITLE
Invoke Rally with explicit subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ To specify the version to check against, add `--distribution-version` when runni
 Example: If you want to benchmark Elasticsearch 6.2.4, run the following command:
 
 ```
-esrally --distribution-version=6.2.4
+esrally race --distribution-version=6.2.4
 ```
 
 How to Contribute

--- a/smoke-test.sh
+++ b/smoke-test.sh
@@ -59,7 +59,7 @@ function run_test {
   for challenge in "${CHALLENGES[@]}"
   do
       info "Testing ${challenge}"
-      esrally --race-id="${RACE_ID}" --test-mode --pipeline=benchmark-only --target-host=127.0.0.1:39200 --track-path="${PWD}/eventdata" --track-params="bulk_indexing_clients:1,number_of_replicas:0,daily_logging_volume:1MB,rate_limit_max:2,rate_limit_duration_secs:5,p1_bulk_indexing_clients:1,p2_bulk_indexing_clients:1,p1_duration_secs:5,p2_duration_secs:5,verbose:false" --challenge="${challenge}" --on-error=abort
+      esrally race --race-id="${RACE_ID}" --test-mode --pipeline=benchmark-only --target-host=127.0.0.1:39200 --track-path="${PWD}/eventdata" --track-params="bulk_indexing_clients:1,number_of_replicas:0,daily_logging_volume:1MB,rate_limit_max:2,rate_limit_duration_secs:5,p1_bulk_indexing_clients:1,p2_bulk_indexing_clients:1,p1_duration_secs:5,p2_duration_secs:5,verbose:false" --challenge="${challenge}" --on-error=abort
   done
 }
 


### PR DESCRIPTION
With this commit we always specify an explicit subcommand as Rally will
soon require it for all invocations.

Relates elastic/rally#1155