### PR TITLE
Add max_concurrent_shard_requests parameter to Kibana runner

### DIFF
--- a/eventdata/challenges/frozen.json
+++ b/eventdata/challenges/frozen.json
@@ -1,3 +1,4 @@
+{% set p_max_concurrent_shard_requests = (max_concurrent_shard_requests | default(10)) %}
 {% set p_pre_filter_shard_size = (pre_filter_shard_size | default(1)) %}
 {% set p_bulk_idx_iterations = (bulk_indexing_iterations | default(30000)) %}
 {% set p_query_iterations = (query_iterations | default(3)) %}
@@ -87,6 +88,7 @@
         "ignore_throttled": false,
         "window_end": "START+25%,END",
         "window_length": "25%",
+        "max_concurrent_shard_requests": {{ p_max_concurrent_shard_requests }},
         "pre_filter_shard_size": {{ p_pre_filter_shard_size }}
       },
       "iterations": {{ p_query_iterations }},
@@ -104,6 +106,7 @@
         "ignore_throttled": false,
         "window_end": "START+25%,END",
         "window_length": "25%",
+        "max_concurrent_shard_requests": {{ p_max_concurrent_shard_requests }},
         "pre_filter_shard_size": {{ p_pre_filter_shard_size }}
       },
       "iterations": {{ p_query_iterations }},

--- a/eventdata/parameter_sources/elasticlogs_kibana_source.py
+++ b/eventdata/parameter_sources/elasticlogs_kibana_source.py
@@ -78,7 +78,8 @@ class ElasticlogsKibanaSource:
                                                 'random' - Length is randomized between START and END interval. Only available when fieldstats_id have been specified.
         "discover_size"                 -   Number of documents to return in Discover. Defaults to 500.
         "ignore_throttled"              -   Boolean indicating whether throttled (frozen) indices should be ignored. Defaults to `true`.
-        "max_concurrent_shard_requests" -   Defines the maximum number of concurrent shard requests that each sub-search request executes per node.
+        "max_concurrent_shard_requests" -   (Optional) Defines the maximum number of concurrent shard requests that each sub-search request executes per node.
+                                            Default is not to set this query parameter which means Elasticsearch will use its default value.
         "pre_filter_shard_size"         -   Defines the `pre_filter_shard_size` parameter used with throttled (frozen) indices. Defaults to 1.
         "debug"                         -   Boolean indicating whether request and response should be logged for debugging. Defaults to `false`.
         "seed"                          -   Optional seed used to randomize window_length and window_end parameters.
@@ -197,7 +198,7 @@ class ElasticlogsKibanaSource:
         request_params = {
             "pre_filter_shard_size": self._pre_filter_shard_size
         }
-        if (self._max_concurrent_shard_requests > 0):
+        if self._max_concurrent_shard_requests > 0:
             request_params["max_concurrent_shard_requests"] = self._max_concurrent_shard_requests
 
         if self._dashboard == "traffic":

--- a/eventdata/parameter_sources/elasticlogs_kibana_source.py
+++ b/eventdata/parameter_sources/elasticlogs_kibana_source.py
@@ -192,11 +192,13 @@ class ElasticlogsKibanaSource:
             "dashboard": self._dashboard,
             "window_length": self._window_length,
             "ignore_throttled": self._ignore_throttled,
-            "pre_filter_shard_size": self._pre_filter_shard_size,
             "debug": self._debug
         }
+        request_params = {
+            "pre_filter_shard_size": self._pre_filter_shard_size
+        }
         if (self._max_concurrent_shard_requests > 0):
-            meta_data["max_concurrent_shard_requests"] = self._max_concurrent_shard_requests
+            request_params["max_concurrent_shard_requests"] = self._max_concurrent_shard_requests
 
         if self._dashboard == "traffic":
             response = {"body": self.__traffic_dashboard(index_pattern, query_string, interval, ts_min_ms, ts_max_ms, self._ignore_throttled)}
@@ -206,6 +208,7 @@ class ElasticlogsKibanaSource:
             response = {"body": self.__discover(self._discover_size, index_pattern, query_string, interval, ts_min_ms, ts_max_ms, self._ignore_throttled)}
 
         response["meta_data"] = meta_data
+        response["params"] = request_params
 
         return response
 

--- a/eventdata/parameter_sources/elasticlogs_kibana_source.py
+++ b/eventdata/parameter_sources/elasticlogs_kibana_source.py
@@ -55,32 +55,33 @@ class ElasticlogsKibanaSource:
     Simulates a set of sample Kibana dashboards for the elasticlogs data set.
 
     It expects the parameter hash to contain the following keys:
-        "dashboard"             -   String indicating which dashboard to simulate. Options are 'traffic', 'content_issues' and 'discover'.
-        "query_string"          -   String indicating file to load or list of strings indicating actual query parameters to randomize during benchmarking. Defaults 
-                                    to ["*"], If a list has been specified, a random value will be selected.
-        "index_pattern"         -   String or list of strings representing the index pattern to query. If a list has
-                                    been specified, a random value will be selected.
-        "window_end"            -   Specification of aggregation window end or period within which it should end. If one single value is specified, 
-                                    that will be used to anchor the window. If two values are given in a comma separated list, the end of the window
-                                    will be randomized within this interval. Values can be either absolute or relative:
-                                        'now' - Always evaluated to the current timestamp. This is the default value.
-                                        'now-1h' - Offset to the current timestamp. Consists of a number and either m (minutes), h (hours) or d (days).
-                                        '2016-12-20 20:12:32' - Exact timestamp.
-                                        'START' - If fieldstats has been run for the index pattern and `@timestamp` field, 'START' can be used to reference the start of this interval.
-                                        'END' - If fieldstats has been run for the index pattern and `@timestamp` field, 'END' can be used to reference the end of this interval.
-                                        'END-40%' - When an interval has been specified based on fieldstats, it is possible to express a volume
-                                        relative to the size of the interval as a percentage. If we assume the interval covers 10 hours, 'END-40%'
-                                        represents the timestamp 4 hours (40% of the 10 hour interval) before the END timestamp.
-        "window_length"         -   String indicating length of the time window to aggregate across. Values can be either absolute 
-                                    or relative. Defaults to '1d'.
-                                        '4d' - Consists of a number and either m (minutes), h (hours) or d (days). Can not be lower than 1 minute.
-                                        '10%' - Length given as percentage of window size. Only available when fieldstats_id have been specified.
-                                        'random' - Length is randomized between START and END interval. Only available when fieldstats_id have been specified.
-        "discover_size"         -   Number of documents to return in Discover. Defaults to 500.
-        "ignore_throttled"      -   Boolean indicating whether throttled (frozen) indices should be ignored. Defaults to `true`.
-        "pre_filter_shard_size" -   Defines the `pre_filter_shard_size` parameter used with throttled (frozen) indices. Defgaults to 1.
-        "debug"                 -   Boolean indicating whether request and response should be logged for debugging. Defaults to `false`.
-        "seed"                  -   Optional seed used to randomize window_length and window_end parameters.
+        "dashboard"                     -   String indicating which dashboard to simulate. Options are 'traffic', 'content_issues' and 'discover'.
+        "query_string"                  -   String indicating file to load or list of strings indicating actual query parameters to randomize during benchmarking. Defaults 
+                                            to ["*"], If a list has been specified, a random value will be selected.
+        "index_pattern"                 -   String or list of strings representing the index pattern to query. If a list has
+                                            been specified, a random value will be selected.
+        "window_end"                    -   Specification of aggregation window end or period within which it should end. If one single value is specified, 
+                                            that will be used to anchor the window. If two values are given in a comma separated list, the end of the window
+                                            will be randomized within this interval. Values can be either absolute or relative:
+                                                'now' - Always evaluated to the current timestamp. This is the default value.
+                                                'now-1h' - Offset to the current timestamp. Consists of a number and either m (minutes), h (hours) or d (days).
+                                                '2016-12-20 20:12:32' - Exact timestamp.
+                                                'START' - If fieldstats has been run for the index pattern and `@timestamp` field, 'START' can be used to reference the start of this interval.
+                                                'END' - If fieldstats has been run for the index pattern and `@timestamp` field, 'END' can be used to reference the end of this interval.
+                                                'END-40%' - When an interval has been specified based on fieldstats, it is possible to express a volume
+                                                relative to the size of the interval as a percentage. If we assume the interval covers 10 hours, 'END-40%'
+                                                represents the timestamp 4 hours (40% of the 10 hour interval) before the END timestamp.
+        "window_length"                 -   String indicating length of the time window to aggregate across. Values can be either absolute 
+                                            or relative. Defaults to '1d'.
+                                                '4d' - Consists of a number and either m (minutes), h (hours) or d (days). Can not be lower than 1 minute.
+                                                '10%' - Length given as percentage of window size. Only available when fieldstats_id have been specified.
+                                                'random' - Length is randomized between START and END interval. Only available when fieldstats_id have been specified.
+        "discover_size"                 -   Number of documents to return in Discover. Defaults to 500.
+        "ignore_throttled"              -   Boolean indicating whether throttled (frozen) indices should be ignored. Defaults to `true`.
+        "max_concurrent_shard_requests" -   Defines the maximum number of concurrent shard requests that each sub-search request executes per node.
+        "pre_filter_shard_size"         -   Defines the `pre_filter_shard_size` parameter used with throttled (frozen) indices. Defaults to 1.
+        "debug"                         -   Boolean indicating whether request and response should be logged for debugging. Defaults to `false`.
+        "seed"                          -   Optional seed used to randomize window_length and window_end parameters.
     """
     def __init__(self, track, params, **kwargs):
         self._params = params
@@ -91,6 +92,7 @@ class ElasticlogsKibanaSource:
         self._discover_size = params.get("discover_size", 500)
         self._ignore_throttled = params.get("ignore_throttled", True)
         self._debug = params.get("debug", False)
+        self._max_concurrent_shard_requests = params.get("max_concurrent_shard_requests", 0)
         self._pre_filter_shard_size = params.get("pre_filter_shard_size", 1)
         self._window_length = params.get("window_length", "1d")
         self.infinite = True
@@ -193,6 +195,8 @@ class ElasticlogsKibanaSource:
             "pre_filter_shard_size": self._pre_filter_shard_size,
             "debug": self._debug
         }
+        if (self._max_concurrent_shard_requests > 0):
+            meta_data["max_concurrent_shard_requests"] = self._max_concurrent_shard_requests
 
         if self._dashboard == "traffic":
             response = {"body": self.__traffic_dashboard(index_pattern, query_string, interval, ts_min_ms, ts_max_ms, self._ignore_throttled)}

--- a/eventdata/runners/kibana_runner.py
+++ b/eventdata/runners/kibana_runner.py
@@ -67,10 +67,13 @@ async def kibana(es, params):
     response["unit"] = "ops"
     response["visualisation_count"] = visualisations
 
+    params = {}
     if "pre_filter_shard_size" in meta_data:
-        result = await es.msearch(body=request, params={"pre_filter_shard_size": meta_data["pre_filter_shard_size"]})
-    else:
-        result = await es.msearch(body=request)
+        params["pre_filter_shard_size"] = meta_data["pre_filter_shard_size"]
+    if "max_concurrent_shard_requests" in meta_data:
+        params["max_concurrent_shard_requests"] = meta_data["max_concurrent_shard_requests"]
+
+    result = await es.msearch(body=request, params=params)
 
     sum_hits = 0
     max_took = 0

--- a/eventdata/runners/kibana_runner.py
+++ b/eventdata/runners/kibana_runner.py
@@ -48,6 +48,7 @@ async def kibana(es, params):
 
     It expects the parameter hash to contain the following keys:
         "body"      - msearch request body representing the Kibana dashboard in the  form of an array of dicts.
+        "params"    - msearch request parameters.
         "meta_data" - Dictionary containing meta data information to be carried through into metrics.
     """
     request = params["body"]

--- a/eventdata/runners/kibana_runner.py
+++ b/eventdata/runners/kibana_runner.py
@@ -51,6 +51,7 @@ async def kibana(es, params):
         "meta_data" - Dictionary containing meta data information to be carried through into metrics.
     """
     request = params["body"]
+    request_params = params["params"]
     meta_data = params["meta_data"]
 
     if meta_data["debug"]:
@@ -63,17 +64,12 @@ async def kibana(es, params):
     for key in meta_data.keys():
         response[key] = meta_data[key]
 
+    response["request_params"] = request_params
     response["weight"] = 1
     response["unit"] = "ops"
     response["visualisation_count"] = visualisations
-
-    params = {}
-    if "pre_filter_shard_size" in meta_data:
-        params["pre_filter_shard_size"] = meta_data["pre_filter_shard_size"]
-    if "max_concurrent_shard_requests" in meta_data:
-        params["max_concurrent_shard_requests"] = meta_data["max_concurrent_shard_requests"]
-
-    result = await es.msearch(body=request, params=params)
+    
+    result = await es.msearch(body=request, params=request_params)
 
     sum_hits = 0
     max_took = 0

--- a/tests/parameter_sources/elasticlogs_kibana_source_test.py
+++ b/tests/parameter_sources/elasticlogs_kibana_source_test.py
@@ -80,7 +80,7 @@ def test_create_content_issues_dashboard(time):
     response = param_source.params()
 
     assert response == load("content_issues")
-    assert "max_concurrent_shard_requests" not in response["meta_data"].keys()
+    assert "max_concurrent_shard_requests" not in response["params"].keys()
 
 
 @mock.patch("time.time")
@@ -94,8 +94,8 @@ def test_create_content_issues_dashboard_with_max_concurrent_shard_requests(time
     }, utcnow=lambda: datetime(year=2019, month=11, day=11))
     response = param_source.params()
 
-    assert "max_concurrent_shard_requests" in response["meta_data"].keys()
-    assert response["meta_data"]["max_concurrent_shard_requests"] == 13
+    assert "max_concurrent_shard_requests" in response["params"].keys()
+    assert response["params"]["max_concurrent_shard_requests"] == 13
 
 
 @mock.patch("time.time")

--- a/tests/parameter_sources/elasticlogs_kibana_source_test.py
+++ b/tests/parameter_sources/elasticlogs_kibana_source_test.py
@@ -80,6 +80,22 @@ def test_create_content_issues_dashboard(time):
     response = param_source.params()
 
     assert response == load("content_issues")
+    assert "max_concurrent_shard_requests" not in response["meta_data"].keys()
+
+
+@mock.patch("time.time")
+def test_create_content_issues_dashboard_with_max_concurrent_shard_requests(time):
+    time.return_value = 5000
+
+    param_source = ElasticlogsKibanaSource(track=StaticTrack(), params={
+        "dashboard": "content_issues",
+        "index_pattern": "elasticlogs-*",
+        "max_concurrent_shard_requests" : 13,
+    }, utcnow=lambda: datetime(year=2019, month=11, day=11))
+    response = param_source.params()
+
+    assert "max_concurrent_shard_requests" in response["meta_data"].keys()
+    assert response["meta_data"]["max_concurrent_shard_requests"] == 13
 
 
 @mock.patch("time.time")

--- a/tests/parameter_sources/resources/expected-content_issues.json
+++ b/tests/parameter_sources/resources/expected-content_issues.json
@@ -401,13 +401,15 @@
       "version": true
     }
   ],
+  "params": {
+    "pre_filter_shard_size": 1
+  },
   "meta_data": {
     "dashboard": "content_issues",
     "debug": false,
     "ignore_throttled": true,
     "index_pattern": "elasticlogs-*",
     "interval": "30m",
-    "pre_filter_shard_size": 1,
     "query_string": "*",
     "window_length": "1d"
   }

--- a/tests/parameter_sources/resources/expected-discover-random-window-length.json
+++ b/tests/parameter_sources/resources/expected-discover-random-window-length.json
@@ -58,6 +58,9 @@
       }
     }
   ],
+  "params": {
+    "pre_filter_shard_size": 1
+  },
   "meta_data": {
     "interval": "30m",
     "index_pattern": "elasticlogs-*",
@@ -65,7 +68,6 @@
     "dashboard": "discover",
     "window_length": "random",
     "ignore_throttled": true,
-    "pre_filter_shard_size": 1,
     "debug": false
   }
 }

--- a/tests/parameter_sources/resources/expected-discover.json
+++ b/tests/parameter_sources/resources/expected-discover.json
@@ -65,7 +65,9 @@
     "dashboard": "discover",
     "window_length": "1d",
     "ignore_throttled": true,
-    "pre_filter_shard_size": 1,
     "debug": false
+  },
+  "params": {
+    "pre_filter_shard_size": 1
   }
 }

--- a/tests/parameter_sources/resources/expected-traffic.json
+++ b/tests/parameter_sources/resources/expected-traffic.json
@@ -590,13 +590,15 @@
       "version": true
     }
   ],
+  "params": {
+    "pre_filter_shard_size": 1
+  },
   "meta_data": {
     "dashboard": "traffic",
     "debug": false,
     "ignore_throttled": true,
     "index_pattern": "elasticlogs-*",
     "interval": "30m",
-    "pre_filter_shard_size": 1,
     "query_string": "*",
     "window_length": "1d"
   }

--- a/tests/runners/kibana_runner_test.py
+++ b/tests/runners/kibana_runner_test.py
@@ -85,7 +85,9 @@ async def test_msearch_with_hits_as_number(es):
             {"index": "elasticlogs-*"},
             {"query": {"match_all": {}}, "from": 0, "size": 10}
         ],
-        "params": {},
+        "params": {
+            "pre_filter_shard_size" : 1
+        },
         "meta_data": {
             "debug": True
         }
@@ -155,7 +157,9 @@ async def test_msearch_with_hits_as_number(es):
         "weight": 1,
         "unit": "ops",
         "visualisation_count": 2,
-        "request_params": {}
+        "request_params": {
+            "pre_filter_shard_size" : 1
+        }
     }
 
 

--- a/tests/runners/kibana_runner_test.py
+++ b/tests/runners/kibana_runner_test.py
@@ -32,6 +32,7 @@ async def test_msearch_without_hits(es):
             {"index": "elasticlogs-*"},
             {"query": {"match_all": {}}, "from": 0, "size": 10}
         ],
+        "params": {},
         "meta_data": {
             "debug": True
         }
@@ -70,6 +71,7 @@ async def test_msearch_without_hits(es):
         "weight": 1,
         "unit": "ops",
         "visualisation_count": 2,
+        "request_params": {}
     }
 
 
@@ -83,6 +85,7 @@ async def test_msearch_with_hits_as_number(es):
             {"index": "elasticlogs-*"},
             {"query": {"match_all": {}}, "from": 0, "size": 10}
         ],
+        "params": {},
         "meta_data": {
             "debug": True
         }
@@ -152,6 +155,7 @@ async def test_msearch_with_hits_as_number(es):
         "weight": 1,
         "unit": "ops",
         "visualisation_count": 2,
+        "request_params": {}
     }
 
 
@@ -165,6 +169,7 @@ async def test_msearch_with_hits_as_dict(es):
             {"index": "elasticlogs-*"},
             {"query": {"match_all": {}}, "from": 0, "size": 10}
         ],
+        "params": {},
         "meta_data": {
             "debug": True
         }
@@ -241,6 +246,7 @@ async def test_msearch_with_hits_as_dict(es):
         "weight": 1,
         "unit": "ops",
         "visualisation_count": 2,
+        "request_params": {}
     }
 
 
@@ -252,6 +258,7 @@ async def test_msearch_with_error(es):
             {"index": "elasticlogs-*"},
             {"query": {"match_all": {}}, "from": 0, "size": 10},
         ],
+        "params": {},
         "meta_data": {
             "debug": True
         }
@@ -304,7 +311,8 @@ async def test_msearch_with_error(es):
         "success": False,
         "error-count": 1,
         "error-type": "kibana",
-        "error-description": "HTTP status: 503, message: all shards failed"
+        "error-description": "HTTP status: 503, message: all shards failed",
+        "request_params": {}
     }
 
 


### PR DESCRIPTION
Adds support for the `max_concurrent_shard_requests` request parameter on searches, which is useful to set to higher values in the context of the searchable snapshots frozen tier.

Also slightly refactors the Kibana runner so that request options become a proper thing, making it easier to add more.