### PR TITLE
Allow searchable snapshot runner to mount only subset of indices

### DIFF
--- a/eventdata/runners/mount_searchable_snapshot_runner.py
+++ b/eventdata/runners/mount_searchable_snapshot_runner.py
@@ -15,10 +15,13 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import re
+
 class MountSearchableSnapshotRunner:
     async def __call__(self, es, params):
         repository_name = params["repository"]
         snapshot_name = params["snapshot"]
+        indices = params.get("indices", "*")
         query_params = params.get("query_params")
         snapshots = await es.snapshot.get(repository_name, snapshot_name)
 
@@ -30,8 +33,10 @@ class MountSearchableSnapshotRunner:
 
         for snapshot in available_snapshots:
             for index in snapshot["indices"]:
-                await es.transport.perform_request(method="POST",
-                                                   url=f"/_snapshot/{repository_name}/{snapshot_name}/_mount",
-                                                   body={"index": index},
-                                                   params=query_params
-                                                   )
+                pattern = re.escape(indices).replace(re.escape("*"), ".*")
+                if re.match(pattern, index):
+                    await es.transport.perform_request(method="POST",
+                                                    url=f"/_snapshot/{repository_name}/{snapshot_name}/_mount",
+                                                    body={"index": index},
+                                                    params=query_params
+                                                    )

--- a/eventdata/runners/mount_searchable_snapshot_runner.py
+++ b/eventdata/runners/mount_searchable_snapshot_runner.py
@@ -15,13 +15,13 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import re
+import fnmatch
 
 class MountSearchableSnapshotRunner:
     async def __call__(self, es, params):
         repository_name = params["repository"]
         snapshot_name = params["snapshot"]
-        indices = params.get("indices", "*")
+        index_pattern = params.get("index_pattern", "*")
         query_params = params.get("query_params")
         snapshots = await es.snapshot.get(repository_name, snapshot_name)
 
@@ -33,8 +33,7 @@ class MountSearchableSnapshotRunner:
 
         for snapshot in available_snapshots:
             for index in snapshot["indices"]:
-                pattern = re.escape(indices).replace(re.escape("*"), ".*")
-                if re.match(pattern, index):
+                if fnmatch.fnmatch(index, index_pattern):
                     await es.transport.perform_request(method="POST",
                                                     url=f"/_snapshot/{repository_name}/{snapshot_name}/_mount",
                                                     body={"index": index},

--- a/tests/runners/mount_searchable_snapshot_runner_test.py
+++ b/tests/runners/mount_searchable_snapshot_runner_test.py
@@ -33,21 +33,21 @@ async def test_mount_snapshot_7x(es):
                 "indices": [
                     "elasticlogs-2018-05-03",
                     "elasticlogs-2018-05-04",
-                    "elasticlogs-2018-05-05"
+                    "elasticlogs-2018-06-05"
                 ]
             }
         ]
     })
-    # one call for each index
+    # one call for each matching index
     es.transport.perform_request.side_effect = [
-        as_future(),
         as_future(),
         as_future(),
     ]
 
     params = {
         "repository": "eventdata",
-        "snapshot": "eventdata-snapshot"
+        "snapshot": "eventdata-snapshot",
+        "indices": "elasticlogs-2018-05-*"
     }
 
     runner = MountSearchableSnapshotRunner()
@@ -63,11 +63,7 @@ async def test_mount_snapshot_7x(es):
         mock.call(method="POST",
                   url="/_snapshot/eventdata/eventdata-snapshot/_mount",
                   body={"index": "elasticlogs-2018-05-04"},
-                  params=None),
-        mock.call(method="POST",
-                  url="/_snapshot/eventdata/eventdata-snapshot/_mount",
-                  body={"index": "elasticlogs-2018-05-05"},
-                  params=None),
+                  params=None)
     ])
 
 
@@ -85,23 +81,23 @@ async def test_mount_snapshot_8x(es):
                         "indices": [
                             "elasticlogs-2018-05-03",
                             "elasticlogs-2018-05-04",
-                            "elasticlogs-2018-05-05"
+                            "elasticlogs-2018-06-05"
                         ]
                     }
                 ]
             }
         ]
     })
-    # one call for each index
+    # one call for each matching index
     es.transport.perform_request.side_effect = [
-        as_future(),
         as_future(),
         as_future(),
     ]
 
     params = {
         "repository": "eventdata",
-        "snapshot": "eventdata-snapshot"
+        "snapshot": "eventdata-snapshot",
+        "indices": "elasticlogs-2018-05-*"
     }
 
     runner = MountSearchableSnapshotRunner()
@@ -117,11 +113,7 @@ async def test_mount_snapshot_8x(es):
         mock.call(method="POST",
                   url="/_snapshot/eventdata/eventdata-snapshot/_mount",
                   body={"index": "elasticlogs-2018-05-04"},
-                  params=None),
-        mock.call(method="POST",
-                  url="/_snapshot/eventdata/eventdata-snapshot/_mount",
-                  body={"index": "elasticlogs-2018-05-05"},
-                  params=None),
+                  params=None)
     ])
 
 

--- a/tests/runners/mount_searchable_snapshot_runner_test.py
+++ b/tests/runners/mount_searchable_snapshot_runner_test.py
@@ -47,7 +47,7 @@ async def test_mount_snapshot_7x(es):
     params = {
         "repository": "eventdata",
         "snapshot": "eventdata-snapshot",
-        "indices": "elasticlogs-2018-05-*"
+        "index_pattern": "elasticlogs-2018-05-*"
     }
 
     runner = MountSearchableSnapshotRunner()
@@ -97,7 +97,7 @@ async def test_mount_snapshot_8x(es):
     params = {
         "repository": "eventdata",
         "snapshot": "eventdata-snapshot",
-        "indices": "elasticlogs-2018-05-*"
+        "index_pattern": "elasticlogs-2018-05-*"
     }
 
     runner = MountSearchableSnapshotRunner()


### PR DESCRIPTION
Sometimes we only want to mount a subset of the indices in a snapshot. This generalizes the MountSearchableSnapshotRunner to allow specifying a index pattern so that only a subset of the indices in a snapshot are mounted.