### PR TITLE
Update index prefix for index template

### DIFF
--- a/eventdata/elasticlogs-index-template.json
+++ b/eventdata/elasticlogs-index-template.json
@@ -1,4 +1,4 @@
-{% set p_index_prefix = index_prefix | default("elasticlogs") %}
+{% set p_index_prefix = query_index_prefix | default("elasticlogs") %}
 {% set p_disk_type = disk_type | default('ssd') | lower %}
 {% set p_translog_sync = translog_sync | default('request') | lower %}
 {% set p_refresh_interval = refresh_interval | default("5s") %}


### PR DESCRIPTION
Make it match README that references query_index_prefix instead and make it work as before the changes https://github.com/elastic/rally-eventdata-track/pull/89.

Closes https://github.com/elastic/rally-eventdata-track/issues/107