### PR TITLE
Add check for `hot` and `frozen` for nodestorage runner

### DIFF
--- a/eventdata/runners/nodestorage_runner.py
+++ b/eventdata/runners/nodestorage_runner.py
@@ -44,7 +44,7 @@ async def nodestorage(es, params):
         data_node_count = 0
 
         for node_role in node_role_list:
-            if 'd' in node_role or 'h' in node_role or 'f' in node_role:
+            if node_role in ["c", "d", "f", "h", "w", "s"]:
                 data_node_count += 1
 
         result = await es.indices.stats(index='*', metric='store')

--- a/eventdata/runners/nodestorage_runner.py
+++ b/eventdata/runners/nodestorage_runner.py
@@ -44,7 +44,7 @@ async def nodestorage(es, params):
         data_node_count = 0
 
         for node_role in node_role_list:
-            if 'd' in node_role:
+            if 'd' in node_role or 'h' in node_role or 'f' in node_role:
                 data_node_count += 1
 
         result = await es.indices.stats(index='*', metric='store')


### PR DESCRIPTION
Make the runner work for clusters with data_hot, frozen node roles.

Closes: https://github.com/elastic/rally-eventdata-track/issues/108