### PR TITLE
Make 'nodestorage' runner BWC

### DIFF
--- a/eventdata/runners/nodestorage_runner.py
+++ b/eventdata/runners/nodestorage_runner.py
@@ -39,7 +39,7 @@ async def nodestorage(es, params):
     try:
         # get number of data nodes
         node_role_list = await es.cat.nodes(h="node.role")
-        # In 8.x the response body is no longer bytes
+        # In elasticsearch-py 8.x the response body is no longer bytes
         if isinstance(node_role_list, bytes):
             node_role_list = node_role_list.decode("utf-8")
 

--- a/eventdata/runners/nodestorage_runner.py
+++ b/eventdata/runners/nodestorage_runner.py
@@ -39,7 +39,9 @@ async def nodestorage(es, params):
     try:
         # get number of data nodes
         node_role_list = await es.cat.nodes(h="node.role")
-        node_role_list = node_role_list.decode("utf-8")
+        # In 8.x the response body is no longer bytes
+        if isinstance(node_role_list, bytes):
+            node_role_list = node_role_list.decode("utf-8")
 
         data_node_count = 0
 


### PR DESCRIPTION
Similar to https://github.com/elastic/rally-tracks/pull/380, this ensures the runner is BWC with the 7.x ES client.

You can test this with:
```
esrally race --track-path="/my/path/to/eventdata" --kill-running-processes --test-mode --track-params="number_of_replicas: 0" --test-mode
```