### PR TITLE
Make 'deleteindex_runner' backwards compatible 

### DIFF
--- a/eventdata/runners/deleteindex_runner.py
+++ b/eventdata/runners/deleteindex_runner.py
@@ -68,7 +68,8 @@ async def deleteindex(es, params):
     if max_indices:
         indices = await es.cat.indices(h="index")
         if isinstance(indices, bytes):
-            indices = indices.decode("utf-8").split("\n")
+            indices = indices.decode("utf-8")
+        indices = indices.split("\n")
         indices_by_suffix = {get_suffix(idx, suffix_separator): idx
             for idx in indices
             if fnmatch(idx, index_pattern) and

--- a/eventdata/runners/deleteindex_runner.py
+++ b/eventdata/runners/deleteindex_runner.py
@@ -66,8 +66,9 @@ async def deleteindex(es, params):
     suffix_separator = params.get("suffix_separator", "-")
 
     if max_indices:
-        response = await es.cat.indices(h="index")
-        indices = response.decode("utf-8").split("\n")
+        indices = await es.cat.indices(h="index")
+        if isinstance(indices, bytes):
+            indices = indices.decode("utf-8").split("\n")
         indices_by_suffix = {get_suffix(idx, suffix_separator): idx
             for idx in indices
             if fnmatch(idx, index_pattern) and


### PR DESCRIPTION
Same as https://github.com/elastic/rally-eventdata-track/pull/115, was missed in the last PR.